### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# xHaxe
+# Exercism Haxe Track
 
 Exercism problems in Haxe.
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "haxe",
   "language": "Haxe",
-  "repository": "https://github.com/exercism/xhaxe",
+  "repository": "https://github.com/exercism/haxe",
   "checklist_issue": 2,
   "active": false,
   "test_pattern": "TODO",


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1