### PR TITLE
Call configlet subcommand on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: bash
 
 script:
   - bin/fetch-configlet
-  - bin/configlet .
+  - bin/configlet lint .

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ retest: clean test
 	@cd $(@:%-clean=%) && make clean internal-clean
 
 test-config: bin/configlet
-	@bin/configlet .
+	@bin/configlet lint .
 
 bin/configlet: bin/fetch-configlet
 	@bin/fetch-configlet


### PR DESCRIPTION
This changes configlet to pass a subcommand.

For now, we've released a version of configlet which handles both the old command:

    configlet path/to/track

as well as the new command:

    configlet lint path/to/track

This will let us update all the travis files to include the subcommand before we
release the version of configlet that requires the subcommand.


https://github.com/exercism/configlet/pull/23