### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,23 +5,28 @@
   "checklist_issue": 2,
   "active": false,
   "test_pattern": "TODO",
-  "deprecated": [
-
-  ],
   "foregone": [
 
   ],
   "exercises": [
     {
-      "difficulty": 1,
+      "uuid": "3596bbf7-66f0-49c0-8c3e-3472455f90c7",
       "slug": "hello-world",
+      "active": true,
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
 
       ]
     },
     {
-      "difficulty": 1,
+      "uuid": "46b447aa-b2b5-4f5c-ac73-8de47f897840",
       "slug": "bob",
+      "active": true,
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
 
       ]


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

active: false is the equivalent of _deprecated_, which was stored in a separate array. This array is being removed in this change.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.


See https://github.com/exercism/discussions/issues/159 for the discussion about the new configuration.