### PR TITLE
Add default introductory code example

### DIFF
--- a/docs/SNIPPET.txt
+++ b/docs/SNIPPET.txt
@@ -1,0 +1,7 @@
+package;
+
+class HelloWorld {
+  public static function hello(name : String) : String {
+    return "Hello, " + name + "!";
+  }
+}


### PR DESCRIPTION
Instead of having logic for a fallback in the backend, we're choosing a
default for the snippet file.

For tracks that have core exercises, we pick the first core exercise.
For tracks without these, we pick the first exercise listed in the config.

Note that we're aiming for 10 lines and a max-width of 40 columns.
This solution has a max-width of 59, so we may want to adjust it.

See https://github.com/exercism/meta/issues/89