### PR TITLE
Bringing your track in line with the latest changes to Problem Specifications

### DIFF
--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -1,12 +1,23 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [dd40c4d2-3c8b-44e5-992a-f42b393ec373]
 description = "no matches"
 
 [b3cca662-f50a-489e-ae10-ab8290a09bdc]
 description = "detects two anagrams"
+
+[03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
+description = "detects two anagrams"
+reimplements = "b3cca662-f50a-489e-ae10-ab8290a09bdc"
 
 [a27558ee-9ba0-4552-96b1-ecf665b06556]
 description = "does not detect anagram subsets"

--- a/exercises/practice/forth/.meta/tests.toml
+++ b/exercises/practice/forth/.meta/tests.toml
@@ -1,141 +1,151 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [9962203f-f00a-4a85-b404-8a8ecbcec09d]
-description = "numbers just get pushed onto the stack"
+description = "parsing and numbers -> numbers just get pushed onto the stack"
 
 [9e69588e-a3d8-41a3-a371-ea02206c1e6e]
-description = "can add two numbers"
+description = "addition -> can add two numbers"
 
 [52336dd3-30da-4e5c-8523-bdf9a3427657]
-description = "errors if there is nothing on the stack"
+description = "addition -> errors if there is nothing on the stack"
 
 [06efb9a4-817a-435e-b509-06166993c1b8]
-description = "errors if there is only one value on the stack"
+description = "addition -> errors if there is only one value on the stack"
 
 [09687c99-7bbc-44af-8526-e402f997ccbf]
-description = "can subtract two numbers"
+description = "subtraction -> can subtract two numbers"
 
 [5d63eee2-1f7d-4538-b475-e27682ab8032]
-description = "errors if there is nothing on the stack"
+description = "subtraction -> errors if there is nothing on the stack"
 
 [b3cee1b2-9159-418a-b00d-a1bb3765c23b]
-description = "errors if there is only one value on the stack"
+description = "subtraction -> errors if there is only one value on the stack"
 
 [5df0ceb5-922e-401f-974d-8287427dbf21]
-description = "can multiply two numbers"
+description = "multiplication -> can multiply two numbers"
 
 [9e004339-15ac-4063-8ec1-5720f4e75046]
-description = "errors if there is nothing on the stack"
+description = "multiplication -> errors if there is nothing on the stack"
 
 [8ba4b432-9f94-41e0-8fae-3b3712bd51b3]
-description = "errors if there is only one value on the stack"
+description = "multiplication -> errors if there is only one value on the stack"
 
 [e74c2204-b057-4cff-9aa9-31c7c97a93f5]
-description = "can divide two numbers"
+description = "division -> can divide two numbers"
 
 [54f6711c-4b14-4bb0-98ad-d974a22c4620]
-description = "performs integer division"
+description = "division -> performs integer division"
 
 [a5df3219-29b4-4d2f-b427-81f82f42a3f1]
-description = "errors if dividing by zero"
+description = "division -> errors if dividing by zero"
 
 [1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a]
-description = "errors if there is nothing on the stack"
+description = "division -> errors if there is nothing on the stack"
 
 [d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d]
-description = "errors if there is only one value on the stack"
+description = "division -> errors if there is only one value on the stack"
 
 [ee28d729-6692-4a30-b9be-0d830c52a68c]
-description = "addition and subtraction"
+description = "combined arithmetic -> addition and subtraction"
 
 [40b197da-fa4b-4aca-a50b-f000d19422c1]
-description = "multiplication and division"
+description = "combined arithmetic -> multiplication and division"
 
 [c5758235-6eef-4bf6-ab62-c878e50b9957]
-description = "copies a value on the stack"
+description = "dup -> copies a value on the stack"
 
 [f6889006-5a40-41e7-beb3-43b09e5a22f4]
-description = "copies the top value on the stack"
+description = "dup -> copies the top value on the stack"
 
 [40b7569c-8401-4bd4-a30d-9adf70d11bc4]
-description = "errors if there is nothing on the stack"
+description = "dup -> errors if there is nothing on the stack"
 
 [1971da68-1df2-4569-927a-72bf5bb7263c]
-description = "removes the top value on the stack if it is the only one"
+description = "drop -> removes the top value on the stack if it is the only one"
 
 [8929d9f2-4a78-4e0f-90ad-be1a0f313fd9]
-description = "removes the top value on the stack if it is not the only one"
+description = "drop -> removes the top value on the stack if it is not the only one"
 
 [6dd31873-6dd7-4cb8-9e90-7daa33ba045c]
-description = "errors if there is nothing on the stack"
+description = "drop -> errors if there is nothing on the stack"
 
 [3ee68e62-f98a-4cce-9e6c-8aae6c65a4e3]
-description = "swaps the top two values on the stack if they are the only ones"
+description = "swap -> swaps the top two values on the stack if they are the only ones"
 
 [8ce869d5-a503-44e4-ab55-1da36816ff1c]
-description = "swaps the top two values on the stack if they are not the only ones"
+description = "swap -> swaps the top two values on the stack if they are not the only ones"
 
 [74ba5b2a-b028-4759-9176-c5c0e7b2b154]
-description = "errors if there is nothing on the stack"
+description = "swap -> errors if there is nothing on the stack"
 
 [dd52e154-5d0d-4a5c-9e5d-73eb36052bc8]
-description = "errors if there is only one value on the stack"
+description = "swap -> errors if there is only one value on the stack"
 
 [a2654074-ba68-4f93-b014-6b12693a8b50]
-description = "copies the second element if there are only two"
+description = "over -> copies the second element if there are only two"
 
 [c5b51097-741a-4da7-8736-5c93fa856339]
-description = "copies the second element if there are more than two"
+description = "over -> copies the second element if there are more than two"
 
 [6e1703a6-5963-4a03-abba-02e77e3181fd]
-description = "errors if there is nothing on the stack"
+description = "over -> errors if there is nothing on the stack"
 
 [ee574dc4-ef71-46f6-8c6a-b4af3a10c45f]
-description = "errors if there is only one value on the stack"
+description = "over -> errors if there is only one value on the stack"
 
 [ed45cbbf-4dbf-4901-825b-54b20dbee53b]
-description = "can consist of built-in words"
+description = "user-defined words -> can consist of built-in words"
 
 [2726ea44-73e4-436b-bc2b-5ff0c6aa014b]
-description = "execute in the right order"
+description = "user-defined words -> execute in the right order"
 
 [9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33]
-description = "can override other user-defined words"
+description = "user-defined words -> can override other user-defined words"
 
 [669db3f3-5bd6-4be0-83d1-618cd6e4984b]
-description = "can override built-in words"
+description = "user-defined words -> can override built-in words"
 
 [588de2f0-c56e-4c68-be0b-0bb1e603c500]
-description = "can override built-in operators"
+description = "user-defined words -> can override built-in operators"
 
 [ac12aaaf-26c6-4a10-8b3c-1c958fa2914c]
-description = "can use different words with the same name"
+description = "user-defined words -> can use different words with the same name"
 
 [53f82ef0-2750-4ccb-ac04-5d8c1aefabb1]
-description = "can define word that uses word with the same name"
+description = "user-defined words -> can define word that uses word with the same name"
 
 [35958cee-a976-4a0f-9378-f678518fa322]
-description = "cannot redefine numbers"
+description = "user-defined words -> cannot redefine non-negative numbers"
+
+[df5b2815-3843-4f55-b16c-c3ed507292a7]
+description = "user-defined words -> cannot redefine negative numbers"
 
 [5180f261-89dd-491e-b230-62737e09806f]
-description = "errors if executing a non-existent word"
+description = "user-defined words -> errors if executing a non-existent word"
 
 [7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6]
-description = "DUP is case-insensitive"
+description = "case-insensitivity -> DUP is case-insensitive"
 
 [339ed30b-f5b4-47ff-ab1c-67591a9cd336]
-description = "DROP is case-insensitive"
+description = "case-insensitivity -> DROP is case-insensitive"
 
 [ee1af31e-1355-4b1b-bb95-f9d0b2961b87]
-description = "SWAP is case-insensitive"
+description = "case-insensitivity -> SWAP is case-insensitive"
 
 [acdc3a49-14c8-4cc2-945d-11edee6408fa]
-description = "OVER is case-insensitive"
+description = "case-insensitivity -> OVER is case-insensitive"
 
 [5934454f-a24f-4efc-9fdd-5794e5f0c23c]
-description = "user-defined words are case-insensitive"
+description = "case-insensitivity -> user-defined words are case-insensitive"
 
 [037d4299-195f-4be7-a46d-f07ca6280a06]
-description = "definitions are case-insensitive"
+description = "case-insensitivity -> definitions are case-insensitive"

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
 description = "empty strands"
@@ -20,11 +27,35 @@ description = "long different strands"
 [919f8ef0-b767-4d1b-8516-6379d07fcb28]
 description = "disallow first strand longer"
 
+[b9228bb1-465f-4141-b40f-1f99812de5a8]
+description = "disallow first strand longer"
+reimplements = "919f8ef0-b767-4d1b-8516-6379d07fcb28"
+
 [8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
 description = "disallow second strand longer"
+
+[dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
+description = "disallow second strand longer"
+reimplements = "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e"
 
 [5dce058b-28d4-4ca7-aa64-adfe4e17784c]
 description = "disallow left empty strand"
 
+[db92e77e-7c72-499d-8fe6-9354d2bfd504]
+description = "disallow left empty strand"
+reimplements = "5dce058b-28d4-4ca7-aa64-adfe4e17784c"
+
+[b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]
+description = "disallow empty first strand"
+reimplements = "db92e77e-7c72-499d-8fe6-9354d2bfd504"
+
 [38826d4b-16fb-4639-ac3e-ba027dec8b5f]
 description = "disallow right empty strand"
+
+[920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
+description = "disallow right empty strand"
+reimplements = "38826d4b-16fb-4639-ac3e-ba027dec8b5f"
+
+[9ab9262f-3521-4191-81f5-0ed184a5aa89]
+description = "disallow empty second strand"
+reimplements = "920cd6e3-18f4-4143-b6b8-74270bb8f8a3"

--- a/exercises/practice/kindergarten-garden/.meta/tests.toml
+++ b/exercises/practice/kindergarten-garden/.meta/tests.toml
@@ -1,30 +1,61 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [1fc316ed-17ab-4fba-88ef-3ae78296b692]
-description = "garden with single student"
+description = "partial garden -> garden with single student"
 
 [acd19dc1-2200-4317-bc2a-08f021276b40]
-description = "different garden with single student"
+description = "partial garden -> different garden with single student"
 
 [c376fcc8-349c-446c-94b0-903947315757]
-description = "garden with two students"
+description = "partial garden -> garden with two students"
 
 [2d620f45-9617-4924-9d27-751c80d17db9]
-description = "second student's garden"
+description = "partial garden -> multiple students for the same garden with three students -> second student's garden"
 
 [57712331-4896-4364-89f8-576421d69c44]
-description = "third student's garden"
+description = "partial garden -> multiple students for the same garden with three students -> third student's garden"
 
 [149b4290-58e1-40f2-8ae4-8b87c46e765b]
-description = "first student's garden"
+description = "full garden -> for Alice, first student's garden"
 
 [ba25dbbc-10bd-4a37-b18e-f89ecd098a5e]
-description = "second student's garden"
+description = "full garden -> for Bob, second student's garden"
+
+[566b621b-f18e-4c5f-873e-be30544b838c]
+description = "full garden -> for Charlie"
+
+[3ad3df57-dd98-46fc-9269-1877abf612aa]
+description = "full garden -> for David"
+
+[0f0a55d1-9710-46ed-a0eb-399ba8c72db2]
+description = "full garden -> for Eve"
+
+[a7e80c90-b140-4ea1-aee3-f4625365c9a4]
+description = "full garden -> for Fred"
+
+[9d94b273-2933-471b-86e8-dba68694c615]
+description = "full garden -> for Ginny"
+
+[f55bc6c2-ade8-4844-87c4-87196f1b7258]
+description = "full garden -> for Harriet"
+
+[759070a3-1bb1-4dd4-be2c-7cce1d7679ae]
+description = "full garden -> for Ileana"
+
+[78578123-2755-4d4a-9c7d-e985b8dda1c6]
+description = "full garden -> for Joseph"
 
 [6bb66df7-f433-41ab-aec2-3ead6e99f65b]
-description = "second to last student's garden"
+description = "full garden -> for Kincaid, second to last student's garden"
 
 [d7edec11-6488-418a-94e6-ed509e0fa7eb]
-description = "last student's garden"
+description = "full garden -> for Larry, last student's garden"

--- a/exercises/practice/luhn/.meta/tests.toml
+++ b/exercises/practice/luhn/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [792a7082-feb7-48c7-b88b-bbfec160865e]
 description = "single digit strings can not be valid"
@@ -55,3 +62,6 @@ description = "using ascii value for non-doubled non-digit isn't allowed"
 
 [f94cf191-a62f-4868-bc72-7253114aa157]
 description = "using ascii value for doubled non-digit isn't allowed"
+
+[8b72ad26-c8be-49a2-b99c-bcc3bf631b33]
+description = "non-numeric, non-space char in the middle with a sum that's divisible by 10 isn't allowed"


### PR DESCRIPTION
We're in the process of re-opening the [Problem Specifications repo](https://github.com/exercism/problem-specifications), as discussed in [this issue](https://github.com/exercism/problem-specifications/issues/1674).
This PR adds `.meta/tests.toml` files for all exercises for which canonical data is defined in the Problem Specifications repo.
We'll now discuss _why_ we're making this change.
## Keeping track of implemented tests
While most of the changes to the Problem Specifications repo are specific to that repo, there is one track-specific change:
> If a track implements an exercise for which test data exists, the exercise _must_ contain a `.meta/tests.toml` file.
The goal of the `tests.toml` file is to keep track of which tests are implemented by the exercise.
Tests in this file are identified by their UUID and each test has a boolean value that indicates if it is implemented by that exercise.
A `tests.toml` file for a track's `two-fer` exercise looks like this:
```toml
[canonical-tests]
# no name given
"19709124-b82e-4e86-a722-9e5c5ebf3952" = true
# a name given
"3451eebd-123f-4256-b667-7b109affce32" = true
# another name given
"653611c6-be9f-4935-ab42-978e25fe9a10" = false
```
In this case, the track has chosen to implement two of the three available tests.
If a track uses a _test generator_ to generate an exercise's test suite, it _must_ use the contents of the `tests.toml` file to determine which tests to include in the generated test suite.
## Tooling
To make it easy to keep the `tests.toml` up to date, tracks can use the [`canonical_data_syncer` application](https://github.com/exercism/canonical-data-syncer).
This application is a small, standalone binary that will compare the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data.
It then interactively gives the maintainer the option to include or exclude test cases that are currently missing, updating the `tests.toml` file accordingly.
To use the canonical data syncer tool, tracks should copying the [`fetch-canonical_data_syncer`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer) and/or [`fetch-canonical_data_syncer.ps1`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer.ps1) scripts into their repository.
Then, running either of these scripts will download the latest version of the tool to the track's `bin` directory.
The tool can be run using `./bin/canonical_data_syncer` or `.\bin\canonical_data_syncer.exe`, depending on your operating system.
## Changes
In this PR, we're adding `meta/tests.toml` files for all the exercises for which canonical data is defined.
We've initially marked all tests as _included_, which means that we'll assume that your track has implemented those tests.
If there isn't anything obviously wrong with the PR, I would suggest to merge this PR first, and then later on update the `meta/tests.toml` files according to your track's actual implementation.
