### PR TITLE
Add resistor-color-trio exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -98,6 +98,17 @@
         "filtering",
         "strings"
       ]
+    },
+    {
+      "slug": "resistor-color-trio",
+      "uuid": "130f09c4-dd80-4eaa-bc9d-a38dcd065c8e",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "math",
+		"anonymous-structures"
+      ]
     }
   ]
 }

--- a/exercises/resistor-color-trio/.meta/tests.toml
+++ b/exercises/resistor-color-trio/.meta/tests.toml
@@ -1,0 +1,17 @@
+[canonical-tests]
+
+# Orange and orange and black
+"d6863355-15b7-40bb-abe0-bfb1a25512ed" = true
+
+# Blue and grey and brown
+"1224a3a9-8c8e-4032-843a-5224e04647d6" = true
+
+# Red and black and red
+"b8bda7dc-6b95-4539-abb2-2ad51d66a207" = true
+
+# Green and brown and orange
+"5b1e74bc-d838-4eda-bbb3-eaba988e733b" = true
+
+# Yellow and violet and yellow
+"f5d37ef9-1919-4719-a90d-a33c5a6934c9" = true
+

--- a/exercises/resistor-color-trio/README.md
+++ b/exercises/resistor-color-trio/README.md
@@ -1,0 +1,51 @@
+# Resistor Color Trio
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_. For this exercise, you need to know only three things about them:
+
+- Each resistor has a resistance value.
+- Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+  To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
+- Each band acts as a digit of a number. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+  In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take 3 colors as input, and outputs the correct value, in ohms.
+  The color bands are encoded as follows:
+
+* Black: 0
+* Brown: 1
+* Red: 2
+* Orange: 3
+* Yellow: 4
+* Green: 5
+* Blue: 6
+* Violet: 7
+* Grey: 8
+* White: 9
+
+In `resistor-color duo` you decoded the first two colors. For instance: orange-orange got the main value `33`.
+The third color stands for how many zeros need to be added to the main value. The main value plus the zeros gives us a value in ohms.
+For the exercise it doesn't matter what ohms really are.
+For example:
+
+- orange-orange-black would be 33 and no zeros, which becomes 33 ohms.
+- orange-orange-red would be 33 and 2 zeros, which becomes 3300 ohms.
+- orange-orange-orange would be 33 and 3 zeros, which becomes 33000 ohms.
+
+(If Math is your thing, you may want to think of the zeros as exponents of 10. If Math is not your thing, go with the zeros. It really is the same thing, just in plain English instead of Math lingo.)
+
+This exercise is about translating the colors into a label:
+
+> "... ohms"
+
+So an input of `"orange", "orange", "black"` should return:
+
+> "33 ohms"
+
+When we get more than a thousand ohms, we say "kiloohms". That's similar to saying "kilometer" for 1000 meters, and "kilograms" for 1000 grams.
+So an input of `"orange", "orange", "orange"` should return:
+
+> "33 kiloohms"
+
+## Source
+Maud de Vries, Erik Schierboom
+https://github.com/exercism/problem-specifications/issues/1549
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/resistor-color-trio/src/Example.hx
+++ b/exercises/resistor-color-trio/src/Example.hx
@@ -1,0 +1,22 @@
+package;
+
+typedef ResistanceValue = { unit: String, value: Int };
+
+class ResistorColorTrio {
+    private static final allColors = [
+		"black", "brown",    "red", "orange", "yellow",
+		"green",  "blue", "violet",   "grey",  "white"
+    ];
+
+    public static function label(colors: Array<String>): ResistanceValue { 
+    var val1  = allColors.indexOf(colors[0]);
+    var val2  = allColors.indexOf(colors[1]);
+    var exp   = allColors.indexOf(colors[2]);
+    var value = ((val1 * 10) + val2) * Math.pow(10, exp);
+
+    if (value >= 1000)
+        return { unit: "kiloohms", value: Std.int(value / 1000) };
+    else
+        return { unit: "ohms",     value: Std.int(value) };
+    }
+} 

--- a/exercises/resistor-color-trio/src/ResistorColorTrio.hx
+++ b/exercises/resistor-color-trio/src/ResistorColorTrio.hx
@@ -1,0 +1,9 @@
+package;
+
+typedef ResistanceValue = { unit: String, value: Int };
+
+class ResistorColorTrio {
+    public static function label(colors: Array<String>): ResistanceValue {
+        throw "Not Implemented"; // Delete this statement and write your own implementation.
+    } 
+}

--- a/exercises/resistor-color-trio/test.hxml
+++ b/exercises/resistor-color-trio/test.hxml
@@ -1,0 +1,4 @@
+-x Test
+-lib buddy 
+-cp src/
+-cp test/

--- a/exercises/resistor-color-trio/test/Test.hx
+++ b/exercises/resistor-color-trio/test/Test.hx
@@ -1,0 +1,44 @@
+package;
+
+using buddy.Should;
+
+class Test extends buddy.SingleSuite {
+	public function new() {
+		describe("Resistor Color Trio", {
+			it("Orange and orange and black", {
+				var expected = { unit: "ohms", value: 33 };
+				var result = ResistorColorTrio.label(["orange", "orange", "black"]);
+			for (field in Reflect.fields(result))
+				Reflect.field(result, field).should.be(Reflect.field(expected, field));
+			});
+			it("Blue and grey and brown", {
+				pending("Skipping");
+				var expected = { unit: "ohms", value: 680 };
+				var result = ResistorColorTrio.label(["blue", "grey", "brown"]);
+			for (field in Reflect.fields(result))
+				Reflect.field(result, field).should.be(Reflect.field(expected, field));
+			});
+			it("Red and black and red", {
+				pending("Skipping");
+				var expected = { unit: "kiloohms", value: 2 };
+				var result = ResistorColorTrio.label(["red", "black", "red"]);
+			for (field in Reflect.fields(result))
+				Reflect.field(result, field).should.be(Reflect.field(expected, field));
+			});
+			it("Green and brown and orange", {
+				pending("Skipping");
+				var expected = { unit: "kiloohms", value: 51 };
+				var result = ResistorColorTrio.label(["green", "brown", "orange"]);
+			for (field in Reflect.fields(result))
+				Reflect.field(result, field).should.be(Reflect.field(expected, field));
+			});
+			it("Yellow and violet and yellow", {
+				pending("Skipping");
+				var expected = { unit: "kiloohms", value: 470 };
+				var result = ResistorColorTrio.label(["yellow", "violet", "yellow"]);
+			for (field in Reflect.fields(result))
+				Reflect.field(result, field).should.be(Reflect.field(expected, field));
+			});
+		});
+	}
+}


### PR DESCRIPTION
`Buddy`'s `should.be` doesn't seem to work with anonymous structures which is why the test cases are implemented that way. Granted that's not a fully correct implementation with deep equality like it's done [here](https://github.com/Mahdrentys/Haxe-Deep-Equals/blob/ad05264c932ecddd63e9e4605e91efb5eb710f23/deepequals/DeepEquals.hx#L70), but implementing that as a function to avoid repetition results in test cases having unhelpful failure messages like `Expected true, was false`. I guess it could be wrapped in a macro but I'm not familiar with that. 