### PR TITLE
Enable colorized test output

### DIFF
--- a/exercises/practice/acronym/test.hxml
+++ b/exercises/practice/acronym/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/anagram/test.hxml
+++ b/exercises/practice/anagram/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/binary-search/test.hxml
+++ b/exercises/practice/binary-search/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/bob/test.hxml
+++ b/exercises/practice/bob/test.hxml
@@ -1,4 +1,5 @@
 -x Test
--lib buddy 
+-lib buddy
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/crypto-square/test.hxml
+++ b/exercises/practice/crypto-square/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/darts/test.hxml
+++ b/exercises/practice/darts/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/difference-of-squares/test.hxml
+++ b/exercises/practice/difference-of-squares/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/food-chain/test.hxml
+++ b/exercises/practice/food-chain/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/forth/test.hxml
+++ b/exercises/practice/forth/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/hamming/test.hxml
+++ b/exercises/practice/hamming/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/hello-world/test.hxml
+++ b/exercises/practice/hello-world/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/isbn-verifier/test.hxml
+++ b/exercises/practice/isbn-verifier/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/kindergarten-garden/test.hxml
+++ b/exercises/practice/kindergarten-garden/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/leap/test.hxml
+++ b/exercises/practice/leap/test.hxml
@@ -1,5 +1,6 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/
 

--- a/exercises/practice/luhn/test.hxml
+++ b/exercises/practice/luhn/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/pig-latin/test.hxml
+++ b/exercises/practice/pig-latin/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/protein-translation/test.hxml
+++ b/exercises/practice/protein-translation/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/queen-attack/test.hxml
+++ b/exercises/practice/queen-attack/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/saddle-points/test.hxml
+++ b/exercises/practice/saddle-points/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/secret-handshake/test.hxml
+++ b/exercises/practice/secret-handshake/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/twelve-days/test.hxml
+++ b/exercises/practice/twelve-days/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/

--- a/exercises/practice/two-fer/test.hxml
+++ b/exercises/practice/two-fer/test.hxml
@@ -1,4 +1,5 @@
 -x Test
 -lib buddy 
+-D buddy-colors
 -cp src/
 -cp test/


### PR DESCRIPTION
It's a bit difficult to see the test output at a glance without colors and with test statuses being written at the end of each line. This makes it clearer.