### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,2 +1,4 @@
+# Installation
+
 To install Haxe on Windows, OS X, or Linux, see the official [installation
 instructions](https://haxe.org/download/).

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 ## Running Tests
 The Haxe track relies on the testing framework [Buddy](https://github.com/ciscoheat/buddy).  You can install it with the following:
 


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
