### PR TITLE
Use module-level fields instead of static classes

### DIFF
--- a/exercises/practice/acronym/.meta/Example.hx
+++ b/exercises/practice/acronym/.meta/Example.hx
@@ -1,10 +1,6 @@
-package;
-
-class Acronym {
-    public static function abbreviate(input: String): String {
-        return ~/[-,_]/.replace(input, " ")                 // remove punctuation
-                       .split(" ")                          // split words
-                       .map(w -> w.charAt(0).toUpperCase()) // take first letter
-                       .join("");                           // join as acronym
-    }
+function abbreviate(input:String):String {
+	return ~/[-,_]/.replace(input, " ") // remove punctuation
+		.split(" ") // split words
+		.map(w -> w.charAt(0).toUpperCase()) // take first letter
+		.join(""); // join as acronym
 }

--- a/exercises/practice/acronym/src/Acronym.hx
+++ b/exercises/practice/acronym/src/Acronym.hx
@@ -1,7 +1,3 @@
-package;
-
-class Acronym {
-	public static function abbreviate(input:String):String {
-		throw "Not Implemented"; // Delete this statement and write your own implementation.
-	}
+function abbreviate(input:String):String {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/acronym/test/Test.hx
+++ b/exercises/practice/acronym/test/Test.hx
@@ -8,36 +8,28 @@ class Test extends buddy.SingleSuite {
 			it("basic", {
 				Acronym.abbreviate("Portable Network Graphics").should.be("PNG");
 			});
-			it("lowercase words", {
-				pending("Skipping");
+			xit("lowercase words", {
 				Acronym.abbreviate("Ruby on Rails").should.be("ROR");
 			});
-			it("punctuation", {
-				pending("Skipping");
+			xit("punctuation", {
 				Acronym.abbreviate("First In, First Out").should.be("FIFO");
 			});
-			it("all caps word", {
-				pending("Skipping");
+			xit("all caps word", {
 				Acronym.abbreviate("GNU Image Manipulation Program").should.be("GIMP");
 			});
-			it("punctuation without whitespace", {
-				pending("Skipping");
+			xit("punctuation without whitespace", {
 				Acronym.abbreviate("Complementary metal-oxide semiconductor").should.be("CMOS");
 			});
-			it("very long abbreviation", {
-				pending("Skipping");
+			xit("very long abbreviation", {
 				Acronym.abbreviate("Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me").should.be("ROTFLSHTMDCOALM");
 			});
-			it("consecutive delimiters", {
-				pending("Skipping");
+			xit("consecutive delimiters", {
 				Acronym.abbreviate("Something - I made up from thin air").should.be("SIMUFTA");
 			});
-			it("apostrophes", {
-				pending("Skipping");
+			xit("apostrophes", {
 				Acronym.abbreviate("Halley's Comet").should.be("HC");
 			});
-			it("underscore emphasis", {
-				pending("Skipping");
+			xit("underscore emphasis", {
 				Acronym.abbreviate("The Road _Not_ Taken").should.be("TRNT");
 			});
 		});

--- a/exercises/practice/anagram/.meta/Example.hx
+++ b/exercises/practice/anagram/.meta/Example.hx
@@ -1,17 +1,14 @@
-package;
+function findAnagrams(subject:String, candidates:Array<String>):Array<String> {
+	var anagrams = [
+		for (val in candidates)
+			if (subject.toLowerCase() != val.toLowerCase()) if (sortString(subject.toLowerCase()) == sortString(val.toLowerCase()))
+				val
+	];
+	return anagrams;
+}
 
-class Anagram {
-    public static function findAnagrams(subject: String, candidates: Array<String>): Array<String> {
-        var anagrams = [for (val in candidates) 
-                        if (subject.toLowerCase() != val.toLowerCase())
-                        if (sortString(subject.toLowerCase()) == sortString(val.toLowerCase()))
-                        val];
-        return anagrams;
-    }
-    
-    private static function sortString(string: String): String {
-        var chars = string.split("");
-        chars.sort((c1, c2) -> c1 < c2 ? 1 : -1);
-        return chars.join("");
-    }
+private function sortString(string:String):String {
+	var chars = string.split("");
+	chars.sort((c1, c2) -> c1 < c2 ? 1 : -1);
+	return chars.join("");
 }

--- a/exercises/practice/anagram/src/Anagram.hx
+++ b/exercises/practice/anagram/src/Anagram.hx
@@ -1,7 +1,3 @@
-package;
-
-class Anagram {
-    public static function findAnagrams(subject: String, candidates: Array<String>): Array<String> {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    }
+function findAnagrams(subject:String, candidates:Array<String>):Array<String> {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/anagram/test/Test.hx
+++ b/exercises/practice/anagram/test/Test.hx
@@ -3,64 +3,51 @@ package;
 using buddy.Should;
 
 class Test extends buddy.SingleSuite {
-    public function new() {
-        describe("Anagram", {
-            it("no matches", {
-                Anagram.findAnagrams("diaper", ["hello", "world", "zombies", "pants"]).should.containExactly([]);
-            });
-            it("detects two anagrams", {
-                pending("Skipping");
-                Anagram.findAnagrams("master", ["stream", "pigeon", "maters"]).should.containExactly(["stream", "maters"]);
-            });
-            it("does not detect anagram subsets", {
-                pending("Skipping");
-                Anagram.findAnagrams("good", ["dog", "goody"]).should.containExactly([]);
-            });
-            it("detects anagram", {
-                pending("Skipping");
-                Anagram.findAnagrams("listen", ["enlists", "google", "inlets", "banana"]).should.containExactly(["inlets"]);
-            });
-            it("detects three anagrams", {
-                pending("Skipping");
-                Anagram.findAnagrams("allergy", ["gallery", "ballerina", "regally", "clergy", "largely", "leading"])
-                    .should.containExactly(["gallery", "regally", "largely"]);
-            });
-            it("detects multiple anagrams with different case", {
-                pending("Skipping");
-                Anagram.findAnagrams("nose", ["Eons", "ONES"]).should.containExactly(["Eons", "ONES"]);
-            });
-            it("does not detect non-anagrams with identical checksum", {
-                pending("Skipping");
-                Anagram.findAnagrams("mass", ["last"]).should.containExactly([]);
-            });
-            it("detects anagrams case-insensitively", {
-                pending("Skipping");
-                Anagram.findAnagrams("Orchestra", ["cashregister", "Carthorse", "radishes"]).should.containExactly(["Carthorse"]);
-            });
-            it("detects anagrams using case-insensitive possible matches", {
-                pending("Skipping");
-                Anagram.findAnagrams("Orchestra", ["cashregister", "carthorse", "radishes"]).should.containExactly(["carthorse"]);
-            });
-            it("detects anagrams using case-insensitive possible matches", {
-                pending("Skipping");
-                Anagram.findAnagrams("orchestra", ["cashregister", "Carthorse", "radishes"]).should.containExactly(["Carthorse"]);
-            });
-            it("does not detect an anagram if the original word is repeated", {
-                pending("Skipping");
-                Anagram.findAnagrams("go", ["go Go GO"]).should.containExactly([]);
-            });
-            it("anagrams must use all letters exactly once", {
-                pending("Skipping");
-                Anagram.findAnagrams("tapper", ["patter"]).should.containExactly([]);
-            });
-            it("words are not anagrams of themselves (case-insensitive)", {
-                pending("Skipping");
-                Anagram.findAnagrams("BANANA", ["BANANA", "Banana", "banana"]).should.containExactly([]);
-            });
-            it("words other than themselves can be anagrams", {
-                pending("Skipping");
-                Anagram.findAnagrams("LISTEN", ["Listen", "Silent", "LISTEN"]).should.containExactly(["Silent"]);
-            });
-        });
-    }
+	public function new() {
+		describe("Anagram", {
+			it("no matches", {
+				Anagram.findAnagrams("diaper", ["hello", "world", "zombies", "pants"]).should.containExactly([]);
+			});
+			xit("detects two anagrams", {
+				Anagram.findAnagrams("master", ["stream", "pigeon", "maters"]).should.containExactly(["stream", "maters"]);
+			});
+			xit("does not detect anagram subsets", {
+				Anagram.findAnagrams("good", ["dog", "goody"]).should.containExactly([]);
+			});
+			xit("detects anagram", {
+				Anagram.findAnagrams("listen", ["enlists", "google", "inlets", "banana"]).should.containExactly(["inlets"]);
+			});
+			xit("detects three anagrams", {
+				Anagram.findAnagrams("allergy", ["gallery", "ballerina", "regally", "clergy", "largely", "leading"])
+					.should.containExactly(["gallery", "regally", "largely"]);
+			});
+			xit("detects multiple anagrams with different case", {
+				Anagram.findAnagrams("nose", ["Eons", "ONES"]).should.containExactly(["Eons", "ONES"]);
+			});
+			xit("does not detect non-anagrams with identical checksum", {
+				Anagram.findAnagrams("mass", ["last"]).should.containExactly([]);
+			});
+			xit("detects anagrams case-insensitively", {
+				Anagram.findAnagrams("Orchestra", ["cashregister", "Carthorse", "radishes"]).should.containExactly(["Carthorse"]);
+			});
+			xit("detects anagrams using case-insensitive possible matches", {
+				Anagram.findAnagrams("Orchestra", ["cashregister", "carthorse", "radishes"]).should.containExactly(["carthorse"]);
+			});
+			xit("detects anagrams using case-insensitive possible matches", {
+				Anagram.findAnagrams("orchestra", ["cashregister", "Carthorse", "radishes"]).should.containExactly(["Carthorse"]);
+			});
+			xit("does not detect an anagram if the original word is repeated", {
+				Anagram.findAnagrams("go", ["go Go GO"]).should.containExactly([]);
+			});
+			xit("anagrams must use all letters exactly once", {
+				Anagram.findAnagrams("tapper", ["patter"]).should.containExactly([]);
+			});
+			xit("words are not anagrams of themselves (case-insensitive)", {
+				Anagram.findAnagrams("BANANA", ["BANANA", "Banana", "banana"]).should.containExactly([]);
+			});
+			xit("words other than themselves can be anagrams", {
+				Anagram.findAnagrams("LISTEN", ["Listen", "Silent", "LISTEN"]).should.containExactly(["Silent"]);
+			});
+		});
+	}
 }

--- a/exercises/practice/binary-search/.meta/Example.hx
+++ b/exercises/practice/binary-search/.meta/Example.hx
@@ -1,23 +1,17 @@
-package;
+function find(array:Array<Int>, value:Int):Int {
+	if (array.empty())
+		throw "value not in array";
 
-using Lambda;
+	var midIndex = Std.int(array.length / 2);
+	var midItem = array[midIndex];
 
-class BinarySearch {
-    public static function find(array: Array<Int>, value: Int): Int {
-        if (array.empty())
-            throw "value not in array";
-
-        var midIndex = Std.int(array.length / 2);
-        var midItem = array[midIndex]; 
-
-        if (midItem == value)
-            // found
-            return midIndex;
-        if (value < midItem)
-            // search lhs
-            return find(array.slice(0, midIndex), value);
-        else
-            // search rhs, adding offset
-            return find(array.slice(midIndex + 1), value) + midIndex + 1;
-    } 
+	if (midItem == value)
+		// found
+		return midIndex;
+	if (value < midItem)
+		// search lhs
+		return find(array.slice(0, midIndex), value);
+	else
+		// search rhs, adding offset
+		return find(array.slice(midIndex + 1), value) + midIndex + 1;
 }

--- a/exercises/practice/binary-search/src/BinarySearch.hx
+++ b/exercises/practice/binary-search/src/BinarySearch.hx
@@ -1,7 +1,3 @@
-package;
-
-class BinarySearch {
-    public static function find(array: Array<Int>, value: Int): Int {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    } 
+function find(array:Array<Int>, value:Int):Int {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/binary-search/test/Test.hx
+++ b/exercises/practice/binary-search/test/Test.hx
@@ -2,7 +2,6 @@ package;
 
 using buddy.Should;
 
-// Created by testgen.hx
 class Test extends buddy.SingleSuite {
 	public function new() {
 		describe("Binary Search", {

--- a/exercises/practice/bob/.meta/Example.hx
+++ b/exercises/practice/bob/.meta/Example.hx
@@ -1,31 +1,33 @@
-package;
+function hey(sentence:String):String {
+	final SURE = "Sure.";
+	final CHILL = "Whoa, chill out!";
+	final CALM = "Calm down, I know what I'm doing!";
+	final FINE = "Fine. Be that way!";
+	final WHATEVER = "Whatever.";
 
-class Bob {
-  public static function hey(sentence: String): String {
-    final SURE     = "Sure.";
-    final CHILL    = "Whoa, chill out!";
-    final CALM     = "Calm down, I know what I'm doing!"; 
-    final FINE     = "Fine. Be that way!";
-    final WHATEVER = "Whatever.";
+	if (isQuestion(sentence) && isShouting(sentence))
+		return CALM;
 
-    if (isQuestion(sentence) && 
-        isShouting(sentence))     { return CALM;  }
-    if (isQuestion(sentence))     { return SURE;  }
-    if (isShouting(sentence))     { return CHILL; }
-    if (isSilence(sentence))      { return FINE;  }
-    return WHATEVER;
-  }
+	if (isQuestion(sentence))
+		return SURE;
 
-  private static function isShouting(sentence : String) : Bool {
-    return sentence.toUpperCase() == sentence
-        && sentence.toLowerCase() != sentence;
-  }
+	if (isShouting(sentence))
+		return CHILL;
 
-  private static function isQuestion(sentence : String) : Bool {
-    return StringTools.endsWith(StringTools.trim(sentence), "?");
-  }
+	if (isSilence(sentence))
+		return FINE;
 
-  private static function isSilence(sentence : String) : Bool {
-    return StringTools.trim(sentence) == "";
-  }
+	return WHATEVER;
+}
+
+private function isShouting(sentence:String):Bool {
+	return sentence.toUpperCase() == sentence && sentence.toLowerCase() != sentence;
+}
+
+private function isQuestion(sentence:String):Bool {
+	return StringTools.endsWith(StringTools.trim(sentence), "?");
+}
+
+private function isSilence(sentence:String):Bool {
+	return StringTools.trim(sentence) == "";
 }

--- a/exercises/practice/bob/src/Bob.hx
+++ b/exercises/practice/bob/src/Bob.hx
@@ -1,8 +1,3 @@
-package;
-
-class Bob {
-    public static function hey(sentence: String): String {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    }
+function hey(sentence:String):String {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }
-

--- a/exercises/practice/bob/test/Test.hx
+++ b/exercises/practice/bob/test/Test.hx
@@ -3,114 +3,89 @@ package;
 using buddy.Should;
 
 class Test extends buddy.SingleSuite {
-    public function new() {
-        describe("Bob", {
-            final SURE     = "Sure.";
-            final CHILL    = "Whoa, chill out!";
-            final CALM     = "Calm down, I know what I'm doing!"; 
-            final FINE     = "Fine. Be that way!";
-            final WHATEVER = "Whatever.";
+	public function new() {
+		describe("Bob", {
+			final SURE = "Sure.";
+			final CHILL = "Whoa, chill out!";
+			final CALM = "Calm down, I know what I'm doing!";
+			final FINE = "Fine. Be that way!";
+			final WHATEVER = "Whatever.";
 
-
-            it("stating something", {
-                Bob.hey("Tom-ay-to, tom-aaaah-to.").should.be(WHATEVER);
-            });
-            it("shouting", {
-                pending("Skipping");
-                Bob.hey("WATCH OUT!").should.be(CHILL);
-            });
-            it("shouting gibberish", {
-                pending("Skipping");
-                Bob.hey("FCECDFCAAB").should.be(CHILL);
-            });
-            it("asking a question", {
-                pending("Skipping");
-                Bob.hey("Does this cryogenic chamber make me look fat?").should.be(SURE);
-            });
-            it("asking a numeric question", {
-                pending("Skipping");
-                Bob.hey("You are, what, like 15?").should.be(SURE);
-            });
-            it("asking gibberish", {
-                pending("Skipping");
-                Bob.hey("fffbbcbeab?").should.be(SURE);
-            });
-            it("talking forcefully", {
-                pending("Skipping");
-                Bob.hey("Hi there!").should.be(WHATEVER);
-            });
-            it("using acronyms in regular speech", {
-                pending("Skipping");
-                Bob.hey("It's OK if you don't want to go work for NASA.").should.be(WHATEVER);
-            });
-            it("forceful question", {
-                pending("Skipping");
-                Bob.hey("WHAT'S GOING ON?").should.be(CALM);
-            });
-            it("shouting numbers", {
-                pending("Skipping");
-                Bob.hey("1, 2, 3 GO!").should.be(CHILL);
-            });
-            it("no letters", {
-                pending("Skipping");
-                Bob.hey("1, 2, 3").should.be(WHATEVER);
-            });
-            it("question with no letters", {
-                pending("Skipping");
-                Bob.hey("4?").should.be(SURE);
-            });
-            it("shouting with special characters", {
-                pending("Skipping");
-                Bob.hey("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!").should.be(CHILL);
-            });
-            it("shouting with no exclamation mark", {
-                pending("Skipping");
-                Bob.hey("I HATE THE DENTIST").should.be(CHILL);
-            });
-            it("statement containing question mark", {
-                pending("Skipping");
-                Bob.hey("Ending with ? means a question.").should.be(WHATEVER);
-            });
-            it("non-letters with question", {
-                pending("Skipping");
-                Bob.hey(":) ?").should.be(SURE);
-            });
-            it("prattling on", {
-                pending("Skipping");
-                Bob.hey("Wait! Hang on. Are you going to be OK?").should.be(SURE);
-            });
-            it("silence", {
-                pending("Skipping");
-                Bob.hey("").should.be(FINE);
-            });
-            it("prolonged silence", {
-                pending("Skipping");
-                Bob.hey("          ").should.be(FINE);
-            });
-            it("alternate silence", {
-                pending("Skipping");
-                Bob.hey("\t\t\t\t\t\t\t\t\t\t").should.be(FINE);
-            });
-            it("multiple line question", {
-                pending("Skipping");
-                Bob.hey("\nDoes this cryogenic chamber make me look fat?\nNo.").should.be(WHATEVER);
-            });
-            it("starting with whitespace", {
-                pending("Skipping");
-                Bob.hey("         hmmmmmmm...").should.be(WHATEVER);
-            });
-            it("ending with whitespace", {
-                pending("Skipping");
-                Bob.hey("Okay if like my  spacebar  quite a bit?   ").should.be(SURE);
-            });
-            it("other whitespace", {
-                pending("Skipping");
-                Bob.hey("\n\r \t").should.be(FINE);
-            });
-            it("non-question ending with whitespace", {
-                pending("Skipping");
-                Bob.hey("This is a statement ending with whitespace      ").should.be(WHATEVER);
-            });
-        });
-    }
+			it("stating something", {
+				Bob.hey("Tom-ay-to, tom-aaaah-to.").should.be(WHATEVER);
+			});
+			xit("shouting", {
+				Bob.hey("WATCH OUT!").should.be(CHILL);
+			});
+			xit("shouting gibberish", {
+				Bob.hey("FCECDFCAAB").should.be(CHILL);
+			});
+			xit("asking a question", {
+				Bob.hey("Does this cryogenic chamber make me look fat?").should.be(SURE);
+			});
+			xit("asking a numeric question", {
+				Bob.hey("You are, what, like 15?").should.be(SURE);
+			});
+			xit("asking gibberish", {
+				Bob.hey("fffbbcbeab?").should.be(SURE);
+			});
+			xit("talking forcefully", {
+				Bob.hey("Hi there!").should.be(WHATEVER);
+			});
+			xit("using acronyms in regular speech", {
+				Bob.hey("It's OK if you don't want to go work for NASA.").should.be(WHATEVER);
+			});
+			xit("forceful question", {
+				Bob.hey("WHAT'S GOING ON?").should.be(CALM);
+			});
+			xit("shouting numbers", {
+				Bob.hey("1, 2, 3 GO!").should.be(CHILL);
+			});
+			xit("no letters", {
+				Bob.hey("1, 2, 3").should.be(WHATEVER);
+			});
+			xit("question with no letters", {
+				Bob.hey("4?").should.be(SURE);
+			});
+			xit("shouting with special characters", {
+				Bob.hey("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!").should.be(CHILL);
+			});
+			xit("shouting with no exclamation mark", {
+				Bob.hey("I HATE THE DENTIST").should.be(CHILL);
+			});
+			xit("statement containing question mark", {
+				Bob.hey("Ending with ? means a question.").should.be(WHATEVER);
+			});
+			xit("non-letters with question", {
+				Bob.hey(":) ?").should.be(SURE);
+			});
+			xit("prattling on", {
+				Bob.hey("Wait! Hang on. Are you going to be OK?").should.be(SURE);
+			});
+			xit("silence", {
+				Bob.hey("").should.be(FINE);
+			});
+			xit("prolonged silence", {
+				Bob.hey("          ").should.be(FINE);
+			});
+			xit("alternate silence", {
+				Bob.hey("\t\t\t\t\t\t\t\t\t\t").should.be(FINE);
+			});
+			xit("multiple line question", {
+				Bob.hey("\nDoes this cryogenic chamber make me look fat?\nNo.").should.be(WHATEVER);
+			});
+			xit("starting with whitespace", {
+				Bob.hey("         hmmmmmmm...").should.be(WHATEVER);
+			});
+			xit("ending with whitespace", {
+				Bob.hey("Okay if like my  spacebar  quite a bit?   ").should.be(SURE);
+			});
+			xit("other whitespace", {
+				Bob.hey("\n\r \t").should.be(FINE);
+			});
+			xit("non-question ending with whitespace", {
+				Bob.hey("This is a statement ending with whitespace      ").should.be(WHATEVER);
+			});
+		});
+	}
 }

--- a/exercises/practice/crypto-square/.meta/Example.hx
+++ b/exercises/practice/crypto-square/.meta/Example.hx
@@ -1,51 +1,44 @@
-package;
-
 using StringTools;
 
-class CryptoSquare {
-    public static function ciphertext(plaintext: String): String {
-        return encode(normalize(plaintext));
-    } 
+function ciphertext(plaintext:String):String {
+	return encode(normalize(plaintext));
+}
 
-    private static function normalize(str: String): String {
-        // downcase and remove spaces + punctuation
-        return ~/[^a-z1-9]/gi.replace(str.toLowerCase(), "");
-    }
+private function normalize(str:String):String {
+	// downcase and remove spaces + punctuation
+	return ~/[^a-z1-9]/gi.replace(str.toLowerCase(), "");
+}
 
-    private static function encode(str: String): String {
-        // convert to rectangle (row[])
-        var recSize = getRecSize(str.length);
-        var numRows = recSize.x;
-        var numCols = recSize.y;
-        var rows = [];
-        for (i in 0...numRows) 
-            rows.push(str.substr(i * numCols, numCols));
+private function encode(str:String):String {
+	// convert to rectangle (row[])
+	var recSize = getRecSize(str.length);
+	var numRows = recSize.x;
+	var numCols = recSize.y;
+	var rows = [];
+	for (i in 0...numRows)
+		rows.push(str.substr(i * numCols, numCols));
 
-        // encode by reading down columns, left to right
-        var encoded = new StringBuf();
-        for (i in 0...numCols) {
-            var chunk = "";
-            for (j in 0...numRows) {
-                var char = rows[j].charAt(i);
-                // pad short chunks with spaces
-                char = char == "" ? " " : char;
-                chunk += char;
-            }
-            // separate chunks with space except last one
-            var sep = i == numCols - 1 ? "" : " ";
-            encoded.add(chunk + sep);
-        }
+	// encode by reading down columns, left to right
+	var encoded = new StringBuf();
+	for (i in 0...numCols) {
+		var chunk = "";
+		for (j in 0...numRows) {
+			var char = rows[j].charAt(i);
+			// pad short chunks with spaces
+			char = char == "" ? " " : char;
+			chunk += char;
+		}
+		// separate chunks with space except last one
+		var sep = i == numCols - 1 ? "" : " ";
+		encoded.add(chunk + sep);
+	}
 
-        return encoded.toString();
-    }
+	return encoded.toString();
+}
 
-    // return [nRows, nCols] where c >= r and c - r <= 1
-    private static function getRecSize(count: Int): {x: Int, y: Int} {
-        var square = Math.ceil(Math.sqrt(count));
+// return [nRows, nCols] where c >= r and c - r <= 1
+private function getRecSize(count:Int):{x:Int, y:Int} {
+	var square = Math.ceil(Math.sqrt(count));
 
-        return if ((square - 1) * square < count) 
-            {x: square, y: square};
-        else
-            {x: square - 1, y: square};
-    }
+	return if ((square - 1) * square < count) {x: square, y: square}; else {x: square - 1, y: square};
 }

--- a/exercises/practice/crypto-square/src/CryptoSquare.hx
+++ b/exercises/practice/crypto-square/src/CryptoSquare.hx
@@ -1,7 +1,3 @@
-package;
-
-class CryptoSquare {
-    public static function ciphertext(plaintext: String): String {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    } 
+function ciphertext(plaintext:String):String {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/crypto-square/test/Test.hx
+++ b/exercises/practice/crypto-square/test/Test.hx
@@ -2,7 +2,6 @@ package;
 
 using buddy.Should;
 
-// Created by testgen.hx
 class Test extends buddy.SingleSuite {
 	public function new() {
 		describe("Crypto Square", {

--- a/exercises/practice/darts/.meta/Example.hx
+++ b/exercises/practice/darts/.meta/Example.hx
@@ -1,23 +1,20 @@
-package;
-
 typedef Point = {
-    x: Float, y: Float
+	x:Float,
+	y:Float
 }
 
-class Darts {
-    public static function score(point: Point): Int {
-        var distanceToCenter = Math.sqrt(Math.pow(point.x, 2) + Math.pow(point.y, 2));
-        
-        // landed in inner circle
-        if (distanceToCenter <= 1)
-            return 10;
-        // landed in middle circle
-        if (distanceToCenter <= 5)
-            return 5;
-        // landed in outer circle
-        if (distanceToCenter > 5 && distanceToCenter <= 10)
-            return 1;
-        // landed outside target 
-        return 0;
-    }
+function score(point:Point):Int {
+	var distanceToCenter = Math.sqrt(Math.pow(point.x, 2) + Math.pow(point.y, 2));
+
+	// landed in inner circle
+	if (distanceToCenter <= 1)
+		return 10;
+	// landed in middle circle
+	if (distanceToCenter <= 5)
+		return 5;
+	// landed in outer circle
+	if (distanceToCenter > 5 && distanceToCenter <= 10)
+		return 1;
+	// landed outside target
+	return 0;
 }

--- a/exercises/practice/darts/src/Darts.hx
+++ b/exercises/practice/darts/src/Darts.hx
@@ -1,11 +1,8 @@
-package;
-
 typedef Point = {
-    x: Float, y: Float
+	x:Float,
+	y:Float
 }
 
-class Darts {
-    public static function score(point: Point): Int {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    }
+function score(point:Point):Int {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/difference-of-squares/.meta/Example.hx
+++ b/exercises/practice/difference-of-squares/.meta/Example.hx
@@ -1,18 +1,14 @@
-package;
-
 using Lambda;
 
-class DifferenceOfSquares {
-    public static function squareOfSum(number: Int): Int {
-        var sum = [for (n in 0...number+1) n].fold((val, acc) -> val + acc, 0);
-        return sum * sum;
-    }
+function squareOfSum(number:Int):Int {
+	var sum = [for (n in 0...number + 1) n].fold((val, acc) -> val + acc, 0);
+	return sum * sum;
+}
 
-    public static function sumOfSquares(number: Int): Int {
-        return [for (n in 0...number+1) n * n].fold((val, acc) -> val + acc, 0);
-    }
+function sumOfSquares(number:Int):Int {
+	return [for (n in 0...number + 1) n * n].fold((val, acc) -> val + acc, 0);
+}
 
-    public static function differenceOfSquares(number: Int): Int {
-        return squareOfSum(number) - sumOfSquares(number);
-    }
+function differenceOfSquares(number:Int):Int {
+	return squareOfSum(number) - sumOfSquares(number);
 }

--- a/exercises/practice/difference-of-squares/src/DifferenceOfSquares.hx
+++ b/exercises/practice/difference-of-squares/src/DifferenceOfSquares.hx
@@ -1,15 +1,11 @@
-package;
+function squareOfSum(number:Int):Int {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
+}
 
-class DifferenceOfSquares {
-    public static function squareOfSum(number: Int): Int {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    }
+function sumOfSquares(number:Int):Int {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
+}
 
-    public static function sumOfSquares(number: Int): Int {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    }
-
-    public static function differenceOfSquares(number: Int): Int {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    }
+function differenceOfSquares(number:Int):Int {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/difference-of-squares/test/Test.hx
+++ b/exercises/practice/difference-of-squares/test/Test.hx
@@ -8,40 +8,32 @@ class Test extends buddy.SingleSuite {
 			it("square of sum 1", {
 				DifferenceOfSquares.squareOfSum(1).should().be(1);
 			});
-			it("square of sum 5", {
-				pending("Skipping");
+			xit("square of sum 5", {
 				DifferenceOfSquares.squareOfSum(5).should().be(225);
 			});
-			it("square of sum 100", {
-				pending("Skipping");
+			xit("square of sum 100", {
 				DifferenceOfSquares.squareOfSum(100).should().be(25502500);
 			});
 		});
 		describe("Sum the squares of the numbers up to the given number", {
-			it("sum of squares 1", {
-				pending("Skipping");
+			xit("sum of squares 1", {
 				DifferenceOfSquares.sumOfSquares(1).should().be(1);
 			});
-			it("sum of squares 5", {
-				pending("Skipping");
+			xit("sum of squares 5", {
 				DifferenceOfSquares.sumOfSquares(5).should().be(55);
 			});
-			it("sum of squares 100", {
-				pending("Skipping");
+			xit("sum of squares 100", {
 				DifferenceOfSquares.sumOfSquares(100).should().be(338350);
 			});
 		});
 		describe("Subtract sum of squares from square of sums", {
-			it("difference of squares 1", {
-				pending("Skipping");
+			xit("difference of squares 1", {
 				DifferenceOfSquares.differenceOfSquares(1).should().be(0);
 			});
-			it("difference of squares 5", {
-				pending("Skipping");
+			xit("difference of squares 5", {
 				DifferenceOfSquares.differenceOfSquares(5).should().be(170);
 			});
-			it("difference of squares 100", {
-				pending("Skipping");
+			xit("difference of squares 100", {
 				DifferenceOfSquares.differenceOfSquares(100).should().be(25164150);
 			});
 		});

--- a/exercises/practice/food-chain/.meta/Example.hx
+++ b/exercises/practice/food-chain/.meta/Example.hx
@@ -1,59 +1,55 @@
-package;
+typedef Verses = Array<String>;
 
-typedef Verses = Array<String>
+var pairs = [
+	["fly", "I don't know why she swallowed the fly. Perhaps she'll die."],
+	["spider", "It wriggled and jiggled and tickled inside her."],
+	["bird", "How absurd to swallow a bird!"],
+	["cat", "Imagine that, to swallow a cat!"],
+	["dog", "What a hog, to swallow a dog!"],
+	["goat", "Just opened her throat and swallowed a goat!"],
+	["cow", "I don't know how she swallowed a cow!"],
+	["horse", "She's dead, of course!"]
+];
 
-class FoodChain {
-	static var pairs = [
-		["fly", "I don't know why she swallowed the fly. Perhaps she'll die."],
-		["spider", "It wriggled and jiggled and tickled inside her."],
-		["bird", "How absurd to swallow a bird!"],
-		["cat", "Imagine that, to swallow a cat!"],
-		["dog", "What a hog, to swallow a dog!"],
-		["goat", "Just opened her throat and swallowed a goat!"],
-		["cow", "I don't know how she swallowed a cow!"],
-		["horse", "She's dead, of course!"]
-	];
+function recite(startVerse:Int, endVerse:Int):Verses {
+	var result = [];
 
-	public static function recite(startVerse:Int, endVerse:Int):Verses {
-		var result = [];
+	for (i in startVerse - 1...endVerse)
+		result = result.concat(reciteOne(i));
 
-		for (i in startVerse - 1...endVerse)
-			result = result.concat(reciteOne(i));
+	return result;
+}
 
-		return result;
+function reciteOne(index:Int):Verses {
+	var object = pairs[index][0];
+	var exclamation1 = pairs[index][1];
+	var exclamation2 = pairs[0][1];
+
+	var first = 'I know an old lady who swallowed a $object.';
+	var result = [first, exclamation1];
+
+	// skip fly and horse special cases
+	if (index > 0 && index < 7) {
+		for (i in reciteRec(index, []))
+			result.push(i);
+		result.push(exclamation2);
 	}
 
-	public static function reciteOne(index:Int):Verses {
-		var object = pairs[index][0];
-		var exclamation1 = pairs[index][1];
-		var exclamation2 = pairs[0][1];
+	return result;
+}
 
-		var first = 'I know an old lady who swallowed a $object.';
-		var result = [first, exclamation1];
+private function reciteRec(currIndex:Int, acc:Verses):Verses {
+	if (currIndex <= 0)
+		return acc;
 
-		// skip fly and horse special cases
-		if (index > 0 && index < 7) {
-			for (i in reciteRec(index, []))
-				result.push(i);
-			result.push(exclamation2);
-		}
+	var object1 = pairs[currIndex][0];
+	var object2 = pairs[currIndex - 1][0];
+	var verse = 'She swallowed the $object1 to catch the $object2';
 
-		return result;
-	}
+	// handle spider special case
+	if (currIndex == 2)
+		verse += " that wriggled and jiggled and tickled inside her";
 
-	private static function reciteRec(currIndex:Int, acc:Verses):Verses {
-		if (currIndex <= 0)
-			return acc;
-
-		var object1 = pairs[currIndex][0];
-		var object2 = pairs[currIndex - 1][0];
-		var verse = 'She swallowed the $object1 to catch the $object2';
-
-		// handle spider special case
-		if (currIndex == 2)
-			verse += " that wriggled and jiggled and tickled inside her";
-
-		acc.push('$verse.');
-		return reciteRec(--currIndex, acc);
-	}
+	acc.push('$verse.');
+	return reciteRec(--currIndex, acc);
 }

--- a/exercises/practice/food-chain/src/FoodChain.hx
+++ b/exercises/practice/food-chain/src/FoodChain.hx
@@ -1,7 +1,3 @@
-package;
-
-class FoodChain {
-    public static function recite(startVerse: Int, endVerse: Int): Array<String> {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    } 
+function recite(startVerse:Int, endVerse:Int):Array<String> {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/forth/.meta/Example.hx
+++ b/exercises/practice/forth/.meta/Example.hx
@@ -1,5 +1,3 @@
-package;
-
 using Lambda;
 using StringTools;
 
@@ -11,135 +9,141 @@ enum StackError {
 	DivideByZero;
 }
 
-typedef Stack       = Array<Int>;
-typedef Define      = String -> String;
+typedef Stack = Array<Int>;
+typedef Define = String->String;
 typedef Instruction = String;
 
-class Forth {
-	public static function evaluate(instructions: Array<Instruction>): Stack {
-		function isDefine(ins)
-			return ~/^:.*;$/.match(ins);
+function evaluate(instructions:Array<Instruction>):Stack {
+	function isDefine(ins)
+		return ~/^:.*;$/.match(ins);
 
-		var stack = [];
-		var defines = [];
-		for (instruction in instructions) {
-			// instructions are case-insensitive
-			instruction = instruction.toLowerCase();
+	var stack = [];
+	var defines = [];
+	for (instruction in instructions) {
+		// instructions are case-insensitive
+		instruction = instruction.toLowerCase();
 
-			// stack defines and apply recursively
-			if (isDefine(instruction)) {
-				defines.push(makeDefine(instruction));
-				continue;
-			}
-			instruction = applyDefines(instruction, defines);
+		// stack defines and apply recursively
+		if (isDefine(instruction)) {
+			defines.push(makeDefine(instruction));
+			continue;
+		}
+		instruction = applyDefines(instruction, defines);
 
-			for (token in instruction.split(" ")) {
-				switch (token) {
-					case "+":       add(stack);
-					case "-":       subtract(stack);
-					case "*":       multiply(stack);
-					case "/":       divide(stack);
-					case "dup":     dup(stack);
-					case "drop":    drop(stack);
-					case "swap":    swap(stack);
-					case "over":    over(stack);
-					case n if (Std.parseInt(n) != null):
-						stack.push(Std.parseInt(n));
-					case _:
-						throw StackError.UndefinedOperation;
-				}
+		for (token in instruction.split(" ")) {
+			switch (token) {
+				case "+":
+					add(stack);
+				case "-":
+					subtract(stack);
+				case "*":
+					multiply(stack);
+				case "/":
+					divide(stack);
+				case "dup":
+					dup(stack);
+				case "drop":
+					drop(stack);
+				case "swap":
+					swap(stack);
+				case "over":
+					over(stack);
+				case n if (Std.parseInt(n) != null):
+					stack.push(Std.parseInt(n));
+				case _:
+					throw StackError.UndefinedOperation;
 			}
 		}
-		return stack;
 	}
+	return stack;
+}
 
-	private static function applyDefines(instruction: Instruction, defines: Array<Define>): Instruction {
-		if (defines.empty())
-			return instruction;
+private function applyDefines(instruction:Instruction, defines:Array<Define>):Instruction {
+	if (defines.empty())
+		return instruction;
 
-		return applyDefines(defines.pop()(instruction), defines);
-	}
+	return applyDefines(defines.pop()(instruction), defines);
+}
 
-	private static function makeDefine(instruction: String): Define {
-		var pattern = ~/^: (\S+) (.+) ;$/;
-		pattern.match(instruction);
-		var word = pattern.matched(1);
-		var replacement = pattern.matched(2);
-		if (~/[1-9]/.match(word))
-			throw StackError.IllegalOperation;
+private function makeDefine(instruction:String):Define {
+	var pattern = ~/^: (\S+) (.+) ;$/;
+	pattern.match(instruction);
+	var word = pattern.matched(1);
+	var replacement = pattern.matched(2);
+	if (~/[1-9]/.match(word))
+		throw StackError.IllegalOperation;
 
-		return (ins:String) -> return ins.replace(word, replacement);
-	}
+	return (ins:String) -> return ins.replace(word, replacement);
+}
 
-	private static function validateBinaryOp(a: Int, b: Int): Void {
-		if (a == null && b == null)
-			throw StackError.EmptyStack;
-		if (a == null || b == null)
-			throw StackError.OneValue;
-	}
+private function validateBinaryOp(a:Int, b:Int):Void {
+	if (a == null && b == null)
+		throw StackError.EmptyStack;
+	if (a == null || b == null)
+		throw StackError.OneValue;
+}
 
-	private static function add(stack: Stack): Void {
-		var b = stack.pop(), a = stack.pop();
-		validateBinaryOp(a, b);
+private function add(stack:Stack):Void {
+	var b = stack.pop(), a = stack.pop();
+	validateBinaryOp(a, b);
 
-		stack.push(a + b);
-	}
+	stack.push(a + b);
+}
 
-	private static function subtract(stack: Stack): Void {
-		var b = stack.pop(), a = stack.pop();
-		validateBinaryOp(a, b);
+private function subtract(stack:Stack):Void {
+	var b = stack.pop(), a = stack.pop();
+	validateBinaryOp(a, b);
 
-		stack.push(a - b);
-	}
+	stack.push(a - b);
+}
 
-	private static function multiply(stack: Stack): Void {
-		var b = stack.pop(), a = stack.pop();
-		validateBinaryOp(a, b);
+private function multiply(stack:Stack):Void {
+	var b = stack.pop(), a = stack.pop();
+	validateBinaryOp(a, b);
 
-		stack.push(a * b);
-	}
+	stack.push(a * b);
+}
 
-	private static function divide(stack: Stack): Void {
-		var b = stack.pop(), a = stack.pop();
-		validateBinaryOp(a, b);
+private function divide(stack:Stack):Void {
+	var b = stack.pop(), a = stack.pop();
+	validateBinaryOp(a, b);
 
-		if (b == 0)
-			throw StackError.DivideByZero;
+	if (b == 0)
+		throw StackError.DivideByZero;
 
-		stack.push(Std.int(a / b));
-	}
+	stack.push(Std.int(a / b));
+}
 
-	private static function dup(stack: Stack): Void {
-		var b = stack.pop();
+private function dup(stack:Stack):Void {
+	var b = stack.pop();
 
-		if (b == null)
-			throw StackError.EmptyStack;
+	if (b == null)
+		throw StackError.EmptyStack;
 
-		stack.push(b);
-		stack.push(b);
-	}
+	stack.push(b);
+	stack.push(b);
+}
 
-	private static function drop(stack: Stack): Void {
-		var b = stack.pop();
+private function drop(stack:Stack):Void {
+	var b = stack.pop();
 
-		if (b == null)
-			throw StackError.EmptyStack;
-	}
+	if (b == null)
+		throw StackError.EmptyStack;
+}
 
-	private static function swap(stack: Stack): Void {
-		var b = stack.pop(), a = stack.pop();
-		validateBinaryOp(a, b);
+private function swap(stack:Stack):Void {
+	var b = stack.pop(), a = stack.pop();
+	validateBinaryOp(a, b);
 
-		stack.push(b);
-		stack.push(a);
-	}
+	stack.push(b);
+	stack.push(a);
+}
 
-	private static function over(stack: Stack): Void {
-		var b = stack.pop(), a = stack.pop();
-		validateBinaryOp(a, b);
+private function over(stack:Stack):Void {
+	var b = stack.pop(), a = stack.pop();
+	validateBinaryOp(a, b);
 
-		stack.push(a);
-		stack.push(b);
-		stack.push(a);
-	}
+	stack.push(a);
+	stack.push(b);
+	stack.push(a);
 }

--- a/exercises/practice/forth/src/Forth.hx
+++ b/exercises/practice/forth/src/Forth.hx
@@ -1,5 +1,3 @@
-package;
-
 enum StackError {
 	EmptyStack;
 	OneValue;
@@ -8,8 +6,6 @@ enum StackError {
 	DivideByZero;
 }
 
-class Forth {
-    public static function evaluate(instructions: Array<String>): Array<Int> {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    } 
+function evaluate(instructions:Array<String>):Array<Int> {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/hamming/.meta/Example.hx
+++ b/exercises/practice/hamming/.meta/Example.hx
@@ -1,17 +1,14 @@
-package;
-
 import haxe.Exception;
+
 using Lambda;
 
-class Hamming {
-    public static function distance(strand1: String, strand2: String): Int {
-        if (strand1.length != strand2.length) {
-            throw new Exception("strand lengths must be equal");
-        }
+function distance(strand1:String, strand2:String):Int {
+	if (strand1.length != strand2.length) {
+		throw new Exception("strand lengths must be equal");
+	}
 
-        return [
-            for (i in 0...strand1.length)
-            strand1.charAt(i) != strand2.charAt(i)
-        ].count(p -> p);
-    }
+	return [
+		for (i in 0...strand1.length)
+			strand1.charAt(i) != strand2.charAt(i)
+	].count(p -> p);
 }

--- a/exercises/practice/hamming/src/Hamming.hx
+++ b/exercises/practice/hamming/src/Hamming.hx
@@ -1,7 +1,3 @@
-package;
-
-class Hamming {
-    public static function distance(strand1: String, strand2: String): Int {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    }
+function distance(strand1:String, strand2:String):Int {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/hamming/test/Test.hx
+++ b/exercises/practice/hamming/test/Test.hx
@@ -8,24 +8,19 @@ class Test extends buddy.SingleSuite {
 			it("empty strands", {
 				Hamming.distance("", "").should().be(0);
 			});
-			it("single letter identical strands", {
-				pending("Skpping");
+			xit("single letter identical strands", {
 				Hamming.distance("A", "A").should().be(0);
 			});
-			it("single letter different strands", {
-				pending("Skpping");
+			xit("single letter different strands", {
 				Hamming.distance("G", "T").should().be(1);
 			});
-			it("long identical strands", {
-				pending("Skpping");
+			xit("long identical strands", {
 				Hamming.distance("GGACTGAAATCTG", "GGACTGAAATCTG").should.be(0);
 			});
-			it("long different strands", {
-				pending("Skpping");
+			xit("long different strands", {
 				Hamming.distance("GGACGGATTCTG", "AGGACGGATTCT").should.be(9);
 			});
-			it("disallow first strand longer", {
-				pending("Skpping");
+			xit("disallow first strand longer", {
 				Hamming.distance.bind("AATG", "AAA").should().throwType(haxe.Exception);
 			});
 		});

--- a/exercises/practice/hello-world/.meta/Example.hx
+++ b/exercises/practice/hello-world/.meta/Example.hx
@@ -1,7 +1,3 @@
-package;
-
-class HelloWorld {
-    public static function hello(): String {
-        return "Hello, World!";
-    }
+function hello():String {
+	return "Hello, World!";
 }

--- a/exercises/practice/hello-world/src/HelloWorld.hx
+++ b/exercises/practice/hello-world/src/HelloWorld.hx
@@ -1,7 +1,3 @@
-package;
-
-class HelloWorld {
-    public static function hello(): String {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    }
+function hello():String {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/isbn-verifier/.meta/Example.hx
+++ b/exercises/practice/isbn-verifier/.meta/Example.hx
@@ -1,27 +1,25 @@
-package;
-
 using StringTools;
 using Lambda;
 
-class ISBN {
-    public static function isValid(isbn: String): Bool {
-        // dashes are allowed but ignored
-        isbn = isbn.replace("-", "");    
+function isValid(isbn:String):Bool {
+	// dashes are allowed but ignored
+	isbn = isbn.replace("-", "");
 
-        // a valid isbn consists of 9 digits followed
-        // by a 10th digit or the letter X
-        if (! ~/^[0-9]{9}([0-9]|X)$/.match(isbn))
-            return false;
+	// a valid isbn consists of 9 digits followed
+	// by a 10th digit or the letter X
+	if (!~/^[0-9]{9}([0-9]|X)$/.match(isbn))
+		return false;
 
-        // convert to digits, replacing X with 10
-        function convert(x) return x == "X" ? 10 : Std.parseInt(x); 
-        var digits = isbn.split("").map(convert);
+	// convert to digits, replacing X with 10
+	function convert(x)
+		return x == "X" ? 10 : Std.parseInt(x);
+	var digits = isbn.split("").map(convert);
 
-        // validate using formula:
-        // (x1 * 10 + x2 * 9 ... x10 * 1) mod 11 = 0
-        function sum(a, b) return a + b;
-        var digitSum = digits.mapi((i, x) -> x * (digits.length - i)).fold(sum, 0);
-        
-        return digitSum % 11 == 0;
-    }
+	// validate using formula:
+	// (x1 * 10 + x2 * 9 ... x10 * 1) mod 11 = 0
+	function sum(a, b)
+		return a + b;
+	var digitSum = digits.mapi((i, x) -> x * (digits.length - i)).fold(sum, 0);
+
+	return digitSum % 11 == 0;
 }

--- a/exercises/practice/isbn-verifier/src/ISBN.hx
+++ b/exercises/practice/isbn-verifier/src/ISBN.hx
@@ -1,7 +1,3 @@
-package;
-
-class ISBN {
-    public static function isValid(isbn: String): Bool {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    }
+function isValid(isbn:String):Bool {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/kindergarten-garden/.meta/Example.hx
+++ b/exercises/practice/kindergarten-garden/.meta/Example.hx
@@ -1,41 +1,34 @@
-package;
-
 using StringTools;
 
-class KindergartenGarden {
-	static final plantsPerStudent = 4;
-	static final rowsInGarden = 2;
+private final plantsPerStudent = 4;
+private final rowsInGarden = 2;
+private static var plantNames = ["G" => "grass", "C" => "clover", "R" => "radishes", "V" => "violets"];
 
-	static var plantNames = [
-        "G" => "grass", "C" => "clover", "R" => "radishes", "V" => "violets"
-    ];
+private var students = [
+	 "Alice",    "Bob", "Charlie",   "David",
+	   "Eve",   "Fred",   "Ginny", "Harriet",
+	"Ileana", "Joseph", "Kincaid",   "Larry"
+];
 
-	static var students = [
-		 "Alice",    "Bob", "Charlie",   "David",
-		   "Eve",   "Fred",   "Ginny", "Harriet",
-		"Ileana", "Joseph", "Kincaid",   "Larry"
+function plants(diagram:String, student:String):Array<String> {
+	var garden = makeGarden(diagram);
+	var studentPlants = garden[students.indexOf(student)];
+
+	return studentPlants.split("").map(plantNames.get);
+}
+
+private function makeGarden(diagram:String):Array<String> {
+	var plantsPerRow = Std.int(diagram.length / rowsInGarden);
+	var rows = [for (i in 0...rowsInGarden) diagram.substr(i * plantsPerRow, plantsPerRow)];
+	var numStudents = Std.int(diagram.length / plantsPerStudent);
+	var rowPlantsPerStudent = Std.int(plantsPerStudent / rowsInGarden);
+
+	var garden = [];
+	return [
+		for (i in 0...numStudents)
+			garden[i] = [
+				for (row in rows)
+					row.substr(i * rowPlantsPerStudent, rowPlantsPerStudent)
+			].join("")
 	];
-
-	public static function plants(diagram: String, student: String): Array<String> {
-		var garden = makeGarden(diagram);
-		var studentPlants = garden[students.indexOf(student)];
-
-		return studentPlants.split("").map(plantNames.get);
-	}
-
-	private static function makeGarden(diagram: String): Array<String> {
-		var plantsPerRow = Std.int(diagram.length / rowsInGarden);
-		var rows = [for (i in 0...rowsInGarden) diagram.substr(i * plantsPerRow, plantsPerRow)];
-		var numStudents = Std.int(diagram.length / plantsPerStudent);
-		var rowPlantsPerStudent = Std.int(plantsPerStudent / rowsInGarden);
-
-		var garden = [];
-		return [
-			for (i in 0...numStudents)
-				garden[i] = [
-					for (row in rows)
-						row.substr(i * rowPlantsPerStudent, rowPlantsPerStudent)
-				].join("")
-		];
-	}
 }

--- a/exercises/practice/kindergarten-garden/src/KindergartenGarden.hx
+++ b/exercises/practice/kindergarten-garden/src/KindergartenGarden.hx
@@ -1,7 +1,3 @@
-package;
-
-class KindergartenGarden {
-    public static function plants(diagram: String, student: String): Array<String> {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    } 
+function plants(diagram:String, student:String):Array<String> {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/kindergarten-garden/test/Test.hx
+++ b/exercises/practice/kindergarten-garden/test/Test.hx
@@ -2,7 +2,6 @@ package;
 
 using buddy.Should;
 
-// Created by testgen.hx
 class Test extends buddy.SingleSuite {
 	public function new() {
 		describe("partial garden", {

--- a/exercises/practice/leap/.meta/Example.hx
+++ b/exercises/practice/leap/.meta/Example.hx
@@ -1,7 +1,3 @@
-package;
-
-class Leap {
-    public static function isLeapYear(year: Int): Bool {
-        return ((year % 4 == 0 && year % 100 != 0) || year % 400 == 0);
-    }
+function isLeapYear(year:Int):Bool {
+	return ((year % 4 == 0 && year % 100 != 0) || year % 400 == 0);
 }

--- a/exercises/practice/leap/src/Leap.hx
+++ b/exercises/practice/leap/src/Leap.hx
@@ -1,7 +1,3 @@
-package;
-
-class Leap {
-    public static function isLeapYear(year: Int): Bool {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    }
+function isLeapYear(year:Int):Bool {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/leap/test/Test.hx
+++ b/exercises/practice/leap/test/Test.hx
@@ -2,45 +2,36 @@ package;
 
 using buddy.Should;
 
-
 class Test extends buddy.SingleSuite {
-    public function new() {
-        describe("Leap", {
+	public function new() {
+		describe("Leap", {
 			it("year not divisible by 4 in common year", {
-                Leap.isLeapYear(2015).should.be(false);
+				Leap.isLeapYear(2015).should.be(false);
 			});
-			it("year divisible by 2, not divisible by 4 in common year", {
-                pending("Skipping");
-                Leap.isLeapYear(1970).should.be(false);
+			xit("year divisible by 2, not divisible by 4 in common year", {
+				Leap.isLeapYear(1970).should.be(false);
 			});
-			it("year divisible by 4, not divisible by 100 in leap year", {
-                pending("Skipping");
-                Leap.isLeapYear(1996).should.be(true);
+			xit("year divisible by 4, not divisible by 100 in leap year", {
+				Leap.isLeapYear(1996).should.be(true);
 			});
-			it("year divisible by 4 and 5 is still a leap year", {
-                pending("Skipping");
-                Leap.isLeapYear(1960).should.be(true);
+			xit("year divisible by 4 and 5 is still a leap year", {
+				Leap.isLeapYear(1960).should.be(true);
 			});
-			it("year divisible by 100, not divisible by 400 in common year", {
-                pending("Skipping");
+			xit("year divisible by 100, not divisible by 400 in common year", {
 				Leap.isLeapYear(2100).should.be(false);
 			});
-			it("year divisible by 100 but not by 3 is still not a leap year", {
-                pending("Skipping");
+			xit("year divisible by 100 but not by 3 is still not a leap year", {
 				Leap.isLeapYear(1900).should.be(false);
 			});
-			it("year divisible by 400 in leap year", {
-                pending("Skipping");
+			xit("year divisible by 400 in leap year", {
 				Leap.isLeapYear(2000).should.be(true);
 			});
-			it("year divisible by 400 but not by 125 is still a leap year", {
-                pending("Skipping");
+			xit("year divisible by 400 but not by 125 is still a leap year", {
 				Leap.isLeapYear(2400).should.be(true);
 			});
-			it("year divisible by 200, not divisible by 400 in common year", {
-                pending("Skipping");
+			xit("year divisible by 200, not divisible by 400 in common year", {
 				Leap.isLeapYear(1800).should.be(false);
 			});
-        });
-    }
+		});
+	}
 }

--- a/exercises/practice/luhn/.meta/Example.hx
+++ b/exercises/practice/luhn/.meta/Example.hx
@@ -1,38 +1,34 @@
-package;
-
 using StringTools;
 using Lambda;
 
-class Luhn {
-	public static function valid(input:String):Bool {
-		// spaces are allowed but stripped
-		input = input.replace(" ", "");
+function valid(input:String):Bool {
+	// spaces are allowed but stripped
+	input = input.replace(" ", "");
 
-		// single digit is not valid
-		if (input.length <= 1)
-			return false;
+	// single digit is not valid
+	if (input.length <= 1)
+		return false;
 
-		// only digits are allowed
-		if (~/[^0-9]/.match(input))
-			return false;
+	// only digits are allowed
+	if (~/[^0-9]/.match(input))
+		return false;
 
-		var sum = 0;
-		var second = false; // tracks every other digit
+	var sum = 0;
+	var second = false; // tracks every other digit
 
-		// loop in reverse order
-		for (i in (1 - input.length)...1) {
-			// convert char code to digit value
-			var temp = input.charCodeAt(-i) - '0'.code;
+	// loop in reverse order
+	for (i in (1 - input.length)...1) {
+		// convert char code to digit value
+		var temp = input.charCodeAt(-i) - '0'.code;
 
-			// double every other number
-			if (second)
-				temp *= 2;
+		// double every other number
+		if (second)
+			temp *= 2;
 
-			// subtract 9 if > 9
-			sum += temp > 9 ? temp - 9 : temp;
-			second = !second;
-		}
-
-		return sum % 10 == 0;
+		// subtract 9 if > 9
+		sum += temp > 9 ? temp - 9 : temp;
+		second = !second;
 	}
+
+	return sum % 10 == 0;
 }

--- a/exercises/practice/luhn/src/Luhn.hx
+++ b/exercises/practice/luhn/src/Luhn.hx
@@ -1,7 +1,3 @@
-package;
-
-class Luhn {
-	public static function valid(value:String):Bool {
-		throw "Not Implemented"; // Delete this statement and write your own implementation.
-	}
+function valid(value:String):Bool {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/pig-latin/.meta/Example.hx
+++ b/exercises/practice/pig-latin/.meta/Example.hx
@@ -1,26 +1,22 @@
-package;
+private final vowel = "aeiou".split("").join("|");
+private final consonant = '[^$vowel]';
+private final consonantCluster = "rh ch qu thr th sch".split(" ").join("|");
+private final consonants = '($consonantCluster|$consonant)';
 
-class PigLatin {
-    static final vowel              = "aeiou".split("").join("|");
-    static final consonant          = '[^$vowel]';
-    static final consonantCluster   = "rh ch qu thr th sch".split(" ").join("|");
-    static final consonants         = '($consonantCluster|$consonant)';
+function translate(phrase:String):String
+	return phrase.split(" ").map(translate1).join(" ");
 
-    public static function translate(phrase: String): String 
-        return phrase.split(" ").map(translate1).join(" ");
+private function translate1(word:String):String {
+	var startsWithVowel = new EReg('^($vowel|xr|yt)', "i").match(word);
+	var startsWithConsonant = new EReg('(^${consonants}qu|$consonants)', "i");
 
-    private static function translate1(word: String): String {
-        var startsWithVowel     = new EReg('^($vowel|xr|yt)', "i").match(word);
-        var startsWithConsonant = new EReg('(^${consonants}qu|$consonants)', "i");
+	if (startsWithVowel)
+		return '${word}ay';
 
-        if (startsWithVowel)
-            return '${word}ay';
+	if (startsWithConsonant.match(word)) {
+		var consonant = startsWithConsonant.matched(0);
+		return '${word.substr(consonant.length)}${consonant}ay';
+	}
 
-        if (startsWithConsonant.match(word)) {
-            var consonant = startsWithConsonant.matched(0);
-            return '${word.substr(consonant.length)}${consonant}ay';
-        }
-
-        throw "word was not matched";
-    }
+	throw "word was not matched";
 }

--- a/exercises/practice/pig-latin/src/PigLatin.hx
+++ b/exercises/practice/pig-latin/src/PigLatin.hx
@@ -1,7 +1,3 @@
-package;
-
-class PigLatin {
-    public static function translate(phrase: String): String {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    } 
+function translate(phrase:String):String {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/pig-latin/test/Test.hx
+++ b/exercises/practice/pig-latin/test/Test.hx
@@ -2,7 +2,6 @@ package;
 
 using buddy.Should;
 
-// Created by testgen.hx
 class Test extends buddy.SingleSuite {
 	public function new() {
 		describe("ay is added to words that start with vowels", {

--- a/exercises/practice/protein-translation/.meta/Example.hx
+++ b/exercises/practice/protein-translation/.meta/Example.hx
@@ -1,44 +1,40 @@
-package;
+private inline var STOP = "STOP";
 
-class ProteinTranslation {
-    static inline var STOP = "STOP";
+private final _codon2protein = [
+	["AUG"] => "Methionine",
+	["UUU", "UUC"] => "Phenylalanine",
+	["UUA", "UUG"] => "Leucine",
+	["UCU", "UCC", "UCA", "UCG"] => "Serine",
+	["UAU", "UAC"] => "Tyrosine",
+	["UGU", "UGC"] => "Cysteine",
+	["UGG"] => "Tryptophan",
+	["UAA", "UAG", "UGA"] => STOP
+];
 
-    static final _codon2protein = [
-        ["AUG"]                         => "Methionine",
-        ["UUU", "UUC"]                  => "Phenylalanine",
-        ["UUA", "UUG"]                  => "Leucine",
-        ["UCU", "UCC", "UCA", "UCG"]    => "Serine",
-        ["UAU", "UAC"]                  => "Tyrosine",
-        ["UGU", "UGC"]                  => "Cysteine",
-        ["UGG"]                         => "Tryptophan",
-        ["UAA", "UAG", "UGA"]           => STOP
-    ];
+// transpose into per-codon map
+private final codon2protein = [
+	for (kk => v in _codon2protein)
+		for (k in kk)
+			k => v
+];
 
-    // transpose into per-codon map
-    static final codon2protein = [
-        for (kk => v in _codon2protein) 
-            for (k in kk)
-                k => v
-    ];
+function proteins(strand:String):Array<String> {
+	var proteins = [];
 
-    public static function proteins(strand: String): Array<String> {
-        var proteins = [];
-        
-        for (codon in chunksOf(3, strand)) {
-            var protein = codon2protein[codon];
-            if (protein == STOP)
-                break;
-            else 
-                proteins.push(protein);
-        }
+	for (codon in chunksOf(3, strand)) {
+		var protein = codon2protein[codon];
+		if (protein == STOP)
+			break;
+		else
+			proteins.push(protein);
+	}
 
-        return proteins;
-    }
+	return proteins;
+}
 
-    private static function chunksOf(count: Int, str: String): Array<String> {
-        return [
-            for (i in 0...Std.int(str.length / count))
-                str.substr(i * count, count)
-        ];
-    }
+private function chunksOf(count:Int, str:String):Array<String> {
+	return [
+		for (i in 0...Std.int(str.length / count))
+			str.substr(i * count, count)
+	];
 }

--- a/exercises/practice/protein-translation/src/ProteinTranslation.hx
+++ b/exercises/practice/protein-translation/src/ProteinTranslation.hx
@@ -1,7 +1,3 @@
-package;
-
-class ProteinTranslation {
-	public static function proteins(strand: String): Array<String> {
-		throw "Not Implemented"; // Delete this statement and write your own implementation.
-	}
+function proteins(strand:String):Array<String> {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/queen-attack/.meta/Example.hx
+++ b/exercises/practice/queen-attack/.meta/Example.hx
@@ -1,38 +1,26 @@
-package;
-
 enum CreateResult {
-    Success;
-    Fail(reason: String);
+	Success;
+	Fail(reason:String);
 }
 
 typedef Position = {
-    column: Int,
-    row:    Int
+	column:Int,
+	row:Int
 }
 
-class QueenAttack {
-    static final COLS = 8;
-    static final ROWS = 8;
+private final COLS = 8;
+private final ROWS = 8;
 
-    public static function create(queen: Position): CreateResult {
-        return if (queen.row < 0)
-            Fail("row not positive");
-        else if (queen.row > ROWS - 1)
-            Fail("row not on board");
-        else if (queen.column < 0)
-            Fail("column not positive");
-        else if (queen.column > COLS - 1)
-            Fail("column not on board");
-        else
-            Success;
-    }
+function create(queen:Position):CreateResult {
+	return if (queen.row < 0) Fail("row not positive"); else if (queen.row > ROWS - 1) Fail("row not on board"); else if (queen.column < 0)
+		Fail("column not positive"); else if (queen.column > COLS
+		- 1) Fail("column not on board"); else Success;
+}
 
-	public static function canAttack(white_queen: Position, black_queen: Position): Bool {
-        var sameCol = white_queen.column == black_queen.column;
-        var sameRow = white_queen.row == black_queen.row;
-        var diagonal = 
-            Math.abs(white_queen.column - black_queen.column) == Math.abs(white_queen.row - black_queen.row);
-       
-        return sameCol || sameRow || diagonal;
-    } 
+function canAttack(white_queen:Position, black_queen:Position):Bool {
+	var sameCol = white_queen.column == black_queen.column;
+	var sameRow = white_queen.row == black_queen.row;
+	var diagonal = Math.abs(white_queen.column - black_queen.column) == Math.abs(white_queen.row - black_queen.row);
+
+	return sameCol || sameRow || diagonal;
 }

--- a/exercises/practice/queen-attack/src/QueenAttack.hx
+++ b/exercises/practice/queen-attack/src/QueenAttack.hx
@@ -1,21 +1,17 @@
-package;
-
 enum CreateResult {
-    Success;
-    Fail(reason: String);
+	Success;
+	Fail(reason:String);
 }
 
 typedef Position = {
-    column: Int,
-    row:    Int
+	column:Int,
+	row:Int
 }
 
-class QueenAttack {
-    public static function create(queen: Position): CreateResult {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    }
+function create(queen:Position):CreateResult {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
+}
 
-	public static function canAttack(white_queen: Position, black_queen: Position): Bool {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    } 
+function canAttack(white_queen:Position, black_queen:Position):Bool {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/saddle-points/.meta/Example.hx
+++ b/exercises/practice/saddle-points/.meta/Example.hx
@@ -1,38 +1,34 @@
-package;
-
 typedef Point = {
-    column: Int, row: Int
+	column:Int,
+	row:Int
 }
 
 typedef Matrix = Array<Array<Int>>;
 
-class SaddlePoints {
+function saddlePoints(matrix:Matrix):Array<Point> {
+	var saddlePoints = [];
+	for (row in 0...matrix.length)
+		for (col in 0...matrix[row].length) {
+			var point = {column: col, row: row};
+			if (isSaddlePoint(point, matrix))
+				// normalize
+				saddlePoints.push({column: point.column + 1, row: point.row + 1});
+		}
 
-    public static function saddlePoints(matrix: Matrix): Array<Point> {
-        var saddlePoints = [];
-        for (row in 0...matrix.length)
-            for (col in 0...matrix[row].length) {
-                var point = {column: col, row: row};
-                if (isSaddlePoint(point, matrix))
-                    // normalize
-                    saddlePoints.push({column: point.column + 1, row: point.row + 1});
-            }
+	return saddlePoints;
+}
 
-        return saddlePoints;
-    } 
+private function isSaddlePoint(point:Point, matrix:Matrix):Bool {
+	var val = matrix[point.row][point.column];
 
-    private static function isSaddlePoint(point: Point, matrix: Matrix): Bool {
-        var val = matrix[point.row][point.column];
+	// saddle point is >= all elements in its row
+	for (i in matrix[point.row])
+		if (val < i)
+			return false;
+	// saddle point is <= all elements in its column
+	for (i in 0...matrix.length)
+		if (val > matrix[i][point.column])
+			return false;
 
-        // saddle point is >= all elements in its row
-        for (i in matrix[point.row])
-            if (val < i)
-                return false;
-        // saddle point is <= all elements in its column
-        for (i in 0...matrix.length)
-            if (val > matrix[i][point.column])
-                return false;
-
-        return true;
-    }
+	return true;
 }

--- a/exercises/practice/saddle-points/src/SaddlePoints.hx
+++ b/exercises/practice/saddle-points/src/SaddlePoints.hx
@@ -1,11 +1,8 @@
-package;
-
 typedef Point = {
-    column: Int, row: Int
+	column:Int,
+	row:Int
 }
 
-class SaddlePoints {
-    public static function saddlePoints(matrix: Array<Array<Int>>): Array<Point> {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    } 
+function saddlePoints(matrix:Array<Array<Int>>):Array<Point> {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/secret-handshake/.meta/Example.hx
+++ b/exercises/practice/secret-handshake/.meta/Example.hx
@@ -1,29 +1,21 @@
-package;
-
 using Lambda;
 
-class SecretHandshake {
-	static final cmds = [
-        1 => "wink", 
-        2 => "double blink", 
-        4 => "close your eyes", 
-        8 => "jump"
-    ];
+private final cmds = [1 => "wink", 2 => "double blink", 4 => "close your eyes", 8 => "jump"];
 
-	public static function commands(number:Int):Array<String> {
-		function ascending(a, b) return a > b ? 1 : -1;
-		var sortedKeys = [for (k in cmds.keys()) k];
-		sortedKeys.sort(ascending);
+function commands(number:Int):Array<String> {
+	function ascending(a, b)
+		return a > b ? 1 : -1;
+	var sortedKeys = [for (k in cmds.keys()) k];
+	sortedKeys.sort(ascending);
 
-		var result = [];
-		for (key in sortedKeys)
-			if ((number & key) != 0)
-				result.push(cmds[key]);
+	var result = [];
+	for (key in sortedKeys)
+		if ((number & key) != 0)
+			result.push(cmds[key]);
 
-		var hasReverseCmd = (number & 16) != 0;
-		if (hasReverseCmd)
-			result.reverse();
+	var hasReverseCmd = (number & 16) != 0;
+	if (hasReverseCmd)
+		result.reverse();
 
-		return result;
-	}
+	return result;
 }

--- a/exercises/practice/secret-handshake/src/SecretHandshake.hx
+++ b/exercises/practice/secret-handshake/src/SecretHandshake.hx
@@ -1,7 +1,3 @@
-package;
-
-class SecretHandshake {
-    public static function commands(number: Int): Array<String> {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    } 
+function commands(number:Int):Array<String> {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/secret-handshake/test/Test.hx
+++ b/exercises/practice/secret-handshake/test/Test.hx
@@ -2,7 +2,6 @@ package;
 
 using buddy.Should;
 
-// Created by testgen.hx
 class Test extends buddy.SingleSuite {
 	public function new() {
 		describe("Create a handshake for a number", {

--- a/exercises/practice/twelve-days/.meta/Example.hx
+++ b/exercises/practice/twelve-days/.meta/Example.hx
@@ -1,42 +1,40 @@
-package;
+private var count = [
+	    "a",   "two", "three", "four",   "five",  "six",
+	"seven", "eight",  "nine",  "ten", "eleven", "twelve"
+];
 
-class TwelveDays {
-	static var count = [
-		    "a",   "two", "three", "four",   "five",  "six",
-		"seven", "eight",  "nine",  "ten", "eleven", "twelve"
+private var nth = [
+	  "first", "second", "third", "fourth",    "fifth", "sixth",
+	"seventh", "eighth", "ninth",  "tenth", "eleventh", "twelfth"
+];
+
+private var item = [
+	"Partridge in a Pear Tree",    "Turtle Doves",      "French Hens",   "Calling Birds",
+	              "Gold Rings",  "Geese-a-Laying", "Swans-a-Swimming", "Maids-a-Milking",
+	          "Ladies Dancing", "Lords-a-Leaping",    "Pipers Piping", "Drummers Drumming"
+];
+
+function recite(startVerse:Int, endVerse:Int):Array<String> {
+	return [
+		for (i in startVerse - 1...endVerse) {
+			var start = 'On the ${nth[i]} day of Christmas my true love gave to me: ${count[i]} ${item[i]}';
+			var buf = new StringBuf();
+			buf.add(start);
+			reciteOne(i - 1, buf);
+		}
 	];
-	static var counth = [
-		  "first", "second", "third", "fourth",    "fifth", "sixth",
-		"seventh", "eighth", "ninth",  "tenth", "eleventh", "twelfth"
-	];
-	static var item = [
-		"Partridge in a Pear Tree",    "Turtle Doves",      "French Hens",   "Calling Birds",
-		              "Gold Rings",  "Geese-a-Laying", "Swans-a-Swimming", "Maids-a-Milking",
-		          "Ladies Dancing", "Lords-a-Leaping",    "Pipers Piping", "Drummers Drumming"
-	];
+}
 
-	public static function recite(startVerse: Int, endVerse: Int): Array<String> {
-		return [
-			for (i in startVerse - 1...endVerse) {
-				var start = 'On the ${counth[i]} day of Christmas my true love gave to me: ${count[i]} ${item[i]}';
-				var buf = new StringBuf();
-				buf.add(start);
-				reciteOne(i - 1, buf);
-			}
-		];
-	}
+private function reciteOne(index:Int, acc:StringBuf):String {
+	if (index < 0)
+		return acc.toString() + ".";
 
-	private static function reciteOne(index: Int, acc: StringBuf): String {
-		if (index < 0)
-			return acc.toString() + ".";
+	var verse:String;
+	if (index == 0)
+		verse = ', and ${count[index]} ${item[index]}';
+	else
+		verse = ', ${count[index]} ${item[index]}';
 
-		var verse:String;
-		if (index == 0)
-			verse = ', and ${count[index]} ${item[index]}';
-		else
-			verse = ', ${count[index]} ${item[index]}';
-
-		acc.add(verse);
-		return reciteOne(--index, acc);
-	}
+	acc.add(verse);
+	return reciteOne(--index, acc);
 }

--- a/exercises/practice/twelve-days/src/TwelveDays.hx
+++ b/exercises/practice/twelve-days/src/TwelveDays.hx
@@ -1,7 +1,3 @@
-package;
-
-class TwelveDays {
-    public static function recite(startVerse: Int, endVerse: Int): Array<String> {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    } 
+function recite(startVerse:Int, endVerse:Int):Array<String> {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/twelve-days/test/Test.hx
+++ b/exercises/practice/twelve-days/test/Test.hx
@@ -2,7 +2,6 @@ package;
 
 using buddy.Should;
 
-// Created by testgen.hx
 class Test extends buddy.SingleSuite {
 	public function new() {
 		describe("verse", {

--- a/exercises/practice/two-fer/.meta/Example.hx
+++ b/exercises/practice/two-fer/.meta/Example.hx
@@ -1,7 +1,3 @@
-package;
-
-class TwoFer {
-	public static function twoFer(?name = "you"): String {
-		return 'One for $name, one for me.';
-	}
+function twoFer(?name = "you"):String {
+	return 'One for $name, one for me.';
 }

--- a/exercises/practice/two-fer/src/TwoFer.hx
+++ b/exercises/practice/two-fer/src/TwoFer.hx
@@ -1,7 +1,3 @@
-package;
-
-class TwoFer {
-    public static function twoFer(name: String): String {
-        throw "Not Implemented"; // Delete this statement and write your own implementation.
-    }
+function twoFer(name:String):String {
+	throw "Not Implemented"; // Delete this statement and write your own implementation.
 }

--- a/exercises/practice/two-fer/test/Test.hx
+++ b/exercises/practice/two-fer/test/Test.hx
@@ -8,12 +8,10 @@ class Test extends buddy.SingleSuite {
 			it("no name given", {
 				TwoFer.twoFer(null).should().be("One for you, one for me.");
 			});
-			it("a name given", {
-				pending("Skipping");
+			xit("a name given", {
 				TwoFer.twoFer("Alice").should().be("One for Alice, one for me.");
 			});
-			it("another name given", {
-				pending("Skipping");
+			xit("another name given", {
 				TwoFer.twoFer("Bob").should().be("One for Bob, one for me.");
 			});
 		});


### PR DESCRIPTION
This converts all current practice exercises to use module-level fields introduced in Haxe 4.2, which does away with the unnecessarily enforced OOP structure, removes code redundancy, and simplifies the code structure for parsing by the Representer. For the majority of exercises, the stub becomes as simple as:

```haxe
function someFunction() {
     // add your code here
}
```
From a student's perspective, this enforces the fact that Haxe supports multiple programming paradigms and does not require using OOP when not needed.

The following cleanup tasks were also done along the way:
- Formatting all code using the default config of the Haxe VS formatter
- Unify all test code to use `xit()` for skipping test cases, as `pending()` introduces some issues