### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,25 @@
+{
+  "docs": [
+    {
+      "uuid": "79eb8467-e429-4bf4-8bf7-1cc28ad5d670",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Haxe locally",
+      "blurb": "Learn how to install Haxe locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "77853979-cd8c-4a70-b6f3-2d1f29f383da",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Haxe",
+      "blurb": "An overview of how to get started from scratch with Haxe"
+    },
+    {
+      "uuid": "99cd9a91-555d-45c6-b220-84751e01ffed",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Haxe track",
+      "blurb": "Learn how to test your Haxe exercises on Exercism"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
