### PR TITLE
🤖 Fix invalid UUIDs

### DIFF
--- a/config.json
+++ b/config.json
@@ -206,7 +206,7 @@
       {
         "slug": "leap",
         "name": "Leap",
-        "uuid": "d30952cf-0b7d-a980-9351-caedebfed16362c6a7a",
+        "uuid": "0d4c7c57-7496-411c-a603-caa125c9eae1",
         "practices": ["booleans", "integral-numbers"],
         "prerequisites": ["basics", "booleans", "integral-numbers"],
         "difficulty": 1


### PR DESCRIPTION
This PR regenerates each UUID on the track that was invalid.

To be valid, each value of a `uuid` key must:
- Be a well-formed version 4 UUID (compliant with RFC 4122) in the
  canonical textual representation [1]
- Not exist elsewhere on the track
- Not exist elsewhere on Exercism

A track can generate a suitable UUID by running `configlet uuid`.

In the future, `configlet lint` will produce an error for an invalid
UUID.

[1] That is, it must match this regular expression:
```
^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
```

## Tracking

https://github.com/exercism/v3-launch/issues/29
