### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/src/HelloWorld.hx
+++ b/exercises/practice/hello-world/src/HelloWorld.hx
@@ -1,3 +1,3 @@
 function hello():String {
-	throw "Not Implemented"; // Delete this statement and write your own implementation.
+	return "Goodbye, Mars!";
 }


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46