### PR TITLE
🤖 Remove empty `source` and `source_url` properties

### DIFF
--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -14,6 +14,5 @@
       ".meta/Example.hx"
     ]
   },
-  "source": "Inspired by an exercise created by a professor Della Paolera in Argentina",
-  "source_url": ""
+  "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"
 }

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -16,7 +16,5 @@
     "example": [
       ".meta/Example.hx"
     ]
-  },
-  "source": "",
-  "source_url": ""
+  }
 }


### PR DESCRIPTION
The track CI runs `configlet lint`, which currently exits with a
non-zero exit code if it sees an optional string key that has the value
of the empty string.

This PR therefore removes all such key/value pairs on the track -
they otherwise cause a failing CI check.


---

Tracking: https://github.com/exercism/v3-launch/issues/57
