### PR TITLE
Fix too many instances of strings concept in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -433,7 +433,6 @@
         "name": "Two Fer",
         "uuid": "5b56ea78-58e2-4ef0-931d-d5ccaf9af118",
         "practices": [
-          "strings",
           "string-interpolation",
           "optional-arguments"
         ],

--- a/config.json
+++ b/config.json
@@ -338,7 +338,6 @@
           "maps",
           "array-comprehension",
           "for-loops",
-          "strings",
           "arrays"
         ],
         "prerequisites": [

--- a/config.json
+++ b/config.json
@@ -267,7 +267,6 @@
           "arrays",
           "final",
           "lambda",
-          "strings",
           "for-loops",
           "array-comprehension",
           "maps",

--- a/config.json
+++ b/config.json
@@ -238,7 +238,6 @@
         "name": "Hello World",
         "uuid": "3596bbf7-66f0-49c0-8c3e-3472455f90c7",
         "practices": [
-          "strings"
         ],
         "prerequisites": [],
         "difficulty": 1

--- a/config.json
+++ b/config.json
@@ -222,7 +222,6 @@
         "name": "Hamming",
         "uuid": "ed5e30f2-e9ed-4697-bdc4-99579aea3b6f",
         "practices": [
-          "strings",
           "exceptions",
           "for-loops",
           "lambda"


### PR DESCRIPTION
FIxes the configlet lint warning regarding too many uses of `strings` from #237. I picked five exercises that I believe involve strings but don't allow students to practice them in depth. Removing the `strings`concept from all five would put us at the maximum ten exercises configlet expects for that concept.

In hamming, we iterate over the strands and compare characters one at a time.

In hello-world, the student doesn't practice anything since they're replacing a literal value with another. The literals in question could have been anything specified by the tests.

In two-fer, the student works with default values and string interpolation so this exercise does revolve around strings. However, we just build new strings here and we're not using other string methods so arguably this is a weak candidate for the strings concept.

In kindergarten-garden, the inputs and outputs are strings, but this exercise is more about building an array of strings than working with strings directly.

In protein-translation, similarly, we're working with strings, but only so far as we need to get a sequence of three-letter codon values and then look each one up in a map. Therefore, it's a weak candidate .