### PR TITLE
Update Compiler Target Langs in ABOUT.md

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -2,21 +2,7 @@
 
 Haxe is an open source high-level, strongly-types, cross-platform, object-oriented programming language and compiler that can produce applications and source code, for many different computing platforms from one code-base.
 
-Currently, there are nine supported target languages which allow for different use-cases:
-
-| Name        | Main usages                            |
-| ----------- | -------------------------------------- |
-| JavaScript  | Browser, Desktop, Mobile, Server       |
-| Neko        | Desktop, Server, CLI                   |
-| HashLink    | Desktop, Mobile, Game consoles         |
-| PHP         | Server                                 |
-| Python      | Desktop, Server                        |
-| Lua         | Desktop, Scripting                     |
-| C++         | Desktop, Mobile, Server, Game consoles |
-| Flash       | Desktop, Mobile                        |
-| Java        | Desktop, Mobile, Server                |
-| JVM         | Desktop, Mobile, Server                |
-| C#          | Desktop, Mobile, Server                |
+Currently, there are 12 supported target languages which allow for different use-cases: [Supported Target Languages][supported-target-languages]
 
 [Types][types] introduces the seven different kinds of types in Haxe and how they interact with each other. The discussion of types is continued in [Type System][type-system], where features like unification, type parameters and type inference are explained.
 
@@ -31,3 +17,4 @@ In [Expressions][expressions] we see how to actually get programs to do somethin
 [class-fields]: https://haxe.org/manual/class-field.html
 [expressions]: https://haxe.org/manual/expression.html
 [language-features]: https://haxe.org/manual/lf.html
+[supported-target-languages]: https://haxe.org/documentation/introduction/compiler-targets.html

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -2,7 +2,7 @@
 
 Haxe is an open source high-level, strongly-types, cross-platform, object-oriented programming language and compiler that can produce applications and source code, for many different computing platforms from one code-base.
 
-Currently, there are 12 supported target languages which allow for different use-cases: [Supported Target Languages][supported-target-languages]
+There are several supported target languages which allow for different use-cases: [Supported Target Languages][supported-target-languages]
 
 [Types][types] introduces the seven different kinds of types in Haxe and how they interact with each other. The discussion of types is continued in [Type System][type-system], where features like unification, type parameters and type inference are explained.
 


### PR DESCRIPTION
Updated the ABOUT.md file by removing the table of compiler supported languages and instead referencing the link from the official documentation.