### PR TITLE
Add datetime library to test CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,8 @@ jobs:
       - name: Install testing framework
         run: haxelib install buddy
 
+      - name: Install datetime for gigasecond
+        run: haxelib install datetime
+
       - name: Compile test
         run: bin/build.sh


### PR DESCRIPTION
Partially fixes #64 so the CI won't fail while testing gigasecond.