### PR TITLE
configlet-sync for docs and metadata

### DIFF
--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -16,7 +16,7 @@
       ".meta/Example.hx"
     ]
   },
-  "blurb": "Convert a long phrase to its acronym",
+  "blurb": "Convert a long phrase to its acronym.",
   "source": "Julien Vanier",
   "source_url": "https://github.com/monkbroc"
 }

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -14,6 +14,6 @@
     ]
   },
   "blurb": "Implement the classic method for composing secret messages called a square code.",
-  "source": "J Dalbey's Programming Practice problems.",
-  "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"
+  "source": "J Dalbey's Programming Practice problems",
+  "source_url": "https://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"
 }

--- a/exercises/practice/crypto-square/.meta/tests.toml
+++ b/exercises/practice/crypto-square/.meta/tests.toml
@@ -1,9 +1,19 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [407c3837-9aa7-4111-ab63-ec54b58e8e9f]
 description = "empty plaintext results in an empty ciphertext"
+
+[aad04a25-b8bb-4304-888b-581bea8e0040]
+description = "normalization results in empty plaintext"
 
 [64131d65-6fd9-4f58-bdd8-4a2370fb481d]
 description = "Lowercase"

--- a/exercises/practice/darts/.docs/instructions.md
+++ b/exercises/practice/darts/.docs/instructions.md
@@ -6,6 +6,8 @@ Write a function that returns the earned points in a single toss of a Darts game
 
 In our particular instance of the game, the target rewards 4 different amounts of points, depending on where the dart lands:
 
+![Our dart scoreboard with values from a complete miss to a bullseye](https://assets.exercism.org/images/exercises/darts/darts-scoreboard.svg)
+
 - If the dart lands outside the target, player earns no points (0 points).
 - If the dart lands in the outer circle of the target, player earns 1 point.
 - If the dart lands in the middle circle of the target, player earns 5 points.
@@ -16,8 +18,14 @@ Of course, they are all centered at the same point — that is, the circles are 
 
 Write a function that given a point in the target (defined by its [Cartesian coordinates][cartesian-coordinates] `x` and `y`, where `x` and `y` are [real][real-numbers]), returns the correct amount earned by a dart landing at that point.
 
+## Credit
+
+The scoreboard image was created by [habere-et-dispertire][habere-et-dispertire] using [Inkscape][inkscape].
+
 [darts]: https://en.wikipedia.org/wiki/Darts
 [darts-target]: https://en.wikipedia.org/wiki/Darts#/media/File:Darts_in_a_dartboard.jpg
 [concentric]: https://mathworld.wolfram.com/ConcentricCircles.html
 [cartesian-coordinates]: https://www.mathsisfun.com/data/cartesian-coordinates.html
 [real-numbers]: https://www.mathsisfun.com/numbers/real-numbers.html
+[habere-et-dispertire]: https://exercism.org/profiles/habere-et-dispertire
+[inkscape]: https://en.wikipedia.org/wiki/Inkscape

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -13,6 +13,6 @@
       ".meta/Example.hx"
     ]
   },
-  "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
+  "blurb": "Write a function that returns the earned points in a single toss of a Darts game.",
   "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"
 }

--- a/exercises/practice/food-chain/.meta/config.json
+++ b/exercises/practice/food-chain/.meta/config.json
@@ -16,7 +16,7 @@
       ".meta/Example.hx"
     ]
   },
-  "blurb": "Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'",
+  "blurb": "Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly"
 }

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -16,5 +16,5 @@
       ".meta/Example.hx"
     ]
   },
-  "blurb": "Implement an evaluator for a very simple subset of Forth"
+  "blurb": "Implement an evaluator for a very simple subset of Forth."
 }

--- a/exercises/practice/forth/.meta/tests.toml
+++ b/exercises/practice/forth/.meta/tests.toml
@@ -12,6 +12,9 @@
 [9962203f-f00a-4a85-b404-8a8ecbcec09d]
 description = "parsing and numbers -> numbers just get pushed onto the stack"
 
+[fd7a8da2-6818-4203-a866-fed0714e7aa0]
+description = "parsing and numbers -> pushes negative numbers onto the stack"
+
 [9e69588e-a3d8-41a3-a371-ea02206c1e6e]
 description = "addition -> can add two numbers"
 
@@ -131,6 +134,9 @@ description = "user-defined words -> cannot redefine negative numbers"
 
 [5180f261-89dd-491e-b230-62737e09806f]
 description = "user-defined words -> errors if executing a non-existent word"
+
+[3c8bfef3-edbb-49c1-9993-21d4030043cb]
+description = "user-defined words -> only defines locally"
 
 [7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6]
 description = "case-insensitivity -> DUP is case-insensitive"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -19,7 +19,7 @@
       ".meta/Example.hx"
     ]
   },
-  "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
+  "blurb": "The classical introductory exercise. Just say \"Hello, World!\".",
   "source": "This is an exercise to introduce users to using Exercism",
   "source_url": "https://en.wikipedia.org/wiki/%22Hello,_world!%22_program"
 }

--- a/exercises/practice/isbn-verifier/.meta/tests.toml
+++ b/exercises/practice/isbn-verifier/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [0caa3eac-d2e3-4c29-8df8-b188bc8c9292]
 description = "valid isbn"
@@ -14,8 +21,11 @@ description = "valid isbn with a check digit of 10"
 [3ed50db1-8982-4423-a993-93174a20825c]
 description = "check digit is a character other than X"
 
+[9416f4a5-fe01-4b61-a07b-eb75892ef562]
+description = "invalid check digit in isbn is not treated as zero"
+
 [c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec]
-description = "invalid character in isbn"
+description = "invalid character in isbn is not treated as zero"
 
 [28025280-2c39-4092-9719-f3234b89c627]
 description = "X is only valid as a check digit"
@@ -48,7 +58,10 @@ description = "empty isbn"
 description = "input is 9 characters"
 
 [ed6e8d1b-382c-4081-8326-8b772c581fec]
-description = "invalid characters are not ignored"
+description = "invalid characters are not ignored after checking length"
+
+[daad3e58-ce00-4395-8a8e-e3eded1cdc86]
+description = "invalid characters are not ignored before checking length"
 
 [fb5e48d8-7c03-4bfb-a088-b101df16fdc3]
 description = "input is too long but contains a valid isbn"

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -17,6 +17,6 @@
     ]
   },
   "blurb": "Given a diagram, determine which plants each child in the kindergarten class is responsible for.",
-  "source": "Random musings during airplane trip.",
-  "source_url": "http://jumpstartlab.com"
+  "source": "Exercise by the JumpstartLab team for students at The Turing School of Software and Design.",
+  "source_url": "https://turing.edu"
 }

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -17,6 +17,6 @@
     ]
   },
   "blurb": "Given a year, report if it is a leap year.",
-  "source": "JavaRanch Cattle Drive, exercise 3",
-  "source_url": "http://www.javaranch.com/leap.jsp"
+  "source": "CodeRanch Cattle Drive, Assignment 3",
+  "source_url": "https://coderanch.com/t/718816/Leap"
 }

--- a/exercises/practice/luhn/.meta/tests.toml
+++ b/exercises/practice/luhn/.meta/tests.toml
@@ -33,6 +33,9 @@ description = "invalid credit card"
 [20e67fad-2121-43ed-99a8-14b5b856adb9]
 description = "invalid long number with an even remainder"
 
+[7e7c9fc1-d994-457c-811e-d390d52fba5e]
+description = "invalid long number with a remainder divisible by 5"
+
 [ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa]
 description = "valid number with an even number of digits"
 
@@ -56,6 +59,12 @@ description = "more than a single zero is valid"
 
 [ab56fa80-5de8-4735-8a4a-14dae588663e]
 description = "input digit 9 is correctly converted to output digit 9"
+
+[b9887ee8-8337-46c5-bc45-3bcab51bc36f]
+description = "very long input is valid"
+
+[8a7c0e24-85ea-4154-9cf1-c2db90eabc08]
+description = "valid luhn with an odd number of digits and non zero first digit"
 
 [39a06a5a-5bad-4e0f-b215-b042d46209b1]
 description = "using ascii value for non-doubled non-digit isn't allowed"

--- a/exercises/practice/perfect-numbers/.docs/instructions.md
+++ b/exercises/practice/perfect-numbers/.docs/instructions.md
@@ -1,11 +1,10 @@
 # Instructions
 
-Determine if a number is perfect, abundant, or deficient based on
-Nicomachus' (60 - 120 CE) classification scheme for positive integers.
+Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.
 
 The Greek mathematician [Nicomachus][nicomachus] devised a classification scheme for positive integers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum][aliquot-sum].
 The aliquot sum is defined as the sum of the factors of a number not including the number itself.
-For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
+For example, the aliquot sum of `15` is `1 + 3 + 5 = 9`.
 
 - **Perfect**: aliquot sum = number
   - 6 is a perfect number because (1 + 2 + 3) = 6

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -16,7 +16,7 @@
       ".meta/Example.hx"
     ]
   },
-  "blurb": "Implement a program that translates from English to Pig Latin",
+  "blurb": "Implement a program that translates from English to Pig Latin.",
   "source": "The Pig Latin exercise at Test First Teaching by Ultrasaurus",
   "source_url": "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/"
 }

--- a/exercises/practice/queen-attack/.meta/tests.toml
+++ b/exercises/practice/queen-attack/.meta/tests.toml
@@ -1,39 +1,49 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [3ac4f735-d36c-44c4-a3e2-316f79704203]
-description = "queen with a valid position"
+description = "Test creation of Queens with valid and invalid positions -> queen with a valid position"
 
 [4e812d5d-b974-4e38-9a6b-8e0492bfa7be]
-description = "queen must have positive row"
+description = "Test creation of Queens with valid and invalid positions -> queen must have positive row"
 
 [f07b7536-b66b-4f08-beb9-4d70d891d5c8]
-description = "queen must have row on board"
+description = "Test creation of Queens with valid and invalid positions -> queen must have row on board"
 
 [15a10794-36d9-4907-ae6b-e5a0d4c54ebe]
-description = "queen must have positive column"
+description = "Test creation of Queens with valid and invalid positions -> queen must have positive column"
 
 [6907762d-0e8a-4c38-87fb-12f2f65f0ce4]
-description = "queen must have column on board"
+description = "Test creation of Queens with valid and invalid positions -> queen must have column on board"
 
 [33ae4113-d237-42ee-bac1-e1e699c0c007]
-description = "cannot attack"
+description = "Test the ability of one queen to attack another -> cannot attack"
 
 [eaa65540-ea7c-4152-8c21-003c7a68c914]
-description = "can attack on same row"
+description = "Test the ability of one queen to attack another -> can attack on same row"
 
 [bae6f609-2c0e-4154-af71-af82b7c31cea]
-description = "can attack on same column"
+description = "Test the ability of one queen to attack another -> can attack on same column"
 
 [0e1b4139-b90d-4562-bd58-dfa04f1746c7]
-description = "can attack on first diagonal"
+description = "Test the ability of one queen to attack another -> can attack on first diagonal"
 
 [ff9b7ed4-e4b6-401b-8d16-bc894d6d3dcd]
-description = "can attack on second diagonal"
+description = "Test the ability of one queen to attack another -> can attack on second diagonal"
 
 [0a71e605-6e28-4cc2-aa47-d20a2e71037a]
-description = "can attack on third diagonal"
+description = "Test the ability of one queen to attack another -> can attack on third diagonal"
 
 [0790b588-ae73-4f1f-a968-dd0b34f45f86]
-description = "can attack on fourth diagonal"
+description = "Test the ability of one queen to attack another -> can attack on fourth diagonal"
+
+[543f8fd4-2597-4aad-8d77-cbdab63619f8]
+description = "Test the ability of one queen to attack another -> cannot attack if falling diagonals are only the same when reflected across the longest falling diagonal"

--- a/exercises/practice/resistor-color-trio/.docs/instructions.md
+++ b/exercises/practice/resistor-color-trio/.docs/instructions.md
@@ -23,7 +23,7 @@ For this exercise, you need to know only three things about them:
 - Grey: 8
 - White: 9
 
-In `resistor-color duo` you decoded the first two colors.
+In Resistor Color Duo you decoded the first two colors.
 For instance: orange-orange got the main value `33`.
 The third color stands for how many zeros need to be added to the main value.
 The main value plus the zeros gives us a value in ohms.

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -16,7 +16,7 @@
       ".meta/Example.hx"
     ]
   },
-  "blurb": "Output the lyrics to 'The Twelve Days of Christmas'",
+  "blurb": "Output the lyrics to 'The Twelve Days of Christmas'.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)"
 }

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -16,6 +16,6 @@
       ".meta/Example.hx"
     ]
   },
-  "blurb": "Create a sentence of the form \"One for X, one for me.\"",
+  "blurb": "Create a sentence of the form \"One for X, one for me.\".",
   "source_url": "https://github.com/exercism/problem-specifications/issues/757"
 }


### PR DESCRIPTION
```
./bin/configlet sync --docs --filepaths --metadata
Updating cached 'problem-specifications' data...
Checking exercises...
[warn] docs: instructions unsynced: darts
[warn] docs: instructions unsynced: perfect-numbers
[warn] docs: instructions unsynced: resistor-color-trio
[warn] metadata: unsynced: acronym
[warn] metadata: unsynced: crypto-square
[warn] metadata: unsynced: darts
[warn] metadata: unsynced: food-chain
[warn] metadata: unsynced: forth
[warn] metadata: unsynced: hello-world
[warn] metadata: unsynced: kindergarten-garden
[warn] metadata: unsynced: leap
[warn] metadata: unsynced: pig-latin
[warn] metadata: unsynced: twelve-days
[warn] metadata: unsynced: two-fer
[warn] some exercises have unsynced docs
[warn] some exercises have unsynced metadata
```