### PR TITLE
CI: pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
         haxe-version: [4.2.5]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Setup Haxe environment
-        uses: krdlab/setup-haxe@v1.5.1
+        uses: krdlab/setup-haxe@3437f1adfca98b22815d926271cc39faaf996f25
         with:
           haxe-version: ${{ matrix.haxe-version }}
 


### PR DESCRIPTION
This PR updates GitHub Actions workflows to a specific version.
This ensures that the workflow will always run the same code, which makes your build _stable_.
It will also prevent a potential security issue where a tag could be replaced by a malicious commit without consumers being aware of it.

The PR updates each non-SHA based workflow reference with the SHA of the referenced version/tag, so the current behavior should not change.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-actions-to-shas for more information.