### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 The tests for this exercise rely on the third-party `datetime` library instead of the `Date` class from the standard library. In our testing, the standard Date class did not support [daylight savings time](https://en.wikipedia.org/wiki/Daylight_saving_time) which led to issues with multiple test cases. Please review [the official documentation](https://lib.haxe.org/p/datetime/) for the `datetime` library for any questions.

--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Implementation
+## Track specific instructions
 
 The tests for this exercise rely on the third-party `datetime` library instead of the `Date` class from the standard library. In our testing, the standard Date class did not support [daylight savings time](https://en.wikipedia.org/wiki/Daylight_saving_time) which led to issues with multiple test cases. Please review [the official documentation](https://lib.haxe.org/p/datetime/) for the `datetime` library for any questions.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.